### PR TITLE
[이슈] Fcm Token 쪽에서 Crash 이슈

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/analytics/EventAnalytics.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/analytics/EventAnalytics.kt
@@ -21,4 +21,16 @@ class EventAnalytics(@ApplicationContext context: Context) {
             putString(FirebaseAnalytics.Param.SCREEN_NAME, screenName)
         }
     }
+
+    fun errorEvent(errorMsg: String, screenClass: String) {
+        logEvent(KuRing_Error) {
+            putString(Log, errorMsg)
+            putString(FirebaseAnalytics.Param.SCREEN_NAME, screenClass)
+        }
+    }
+
+    companion object {
+        const val KuRing_Error = "com_kuring_application_error"
+        const val Log = "log"
+    }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/setting_notification/SettingNotificationViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/setting_notification/SettingNotificationViewModel.kt
@@ -20,9 +20,11 @@ import kotlin.Comparator
 @HiltViewModel
 class SettingNotificationViewModel @Inject constructor(
     private val repository: SubscribeRepository,
-    private val pref: PreferenceUtil,
-    private val analytics: EventAnalytics
+    private val pref: PreferenceUtil
 ) : ViewModel(){
+    @Inject
+    lateinit var analytics : EventAnalytics
+
     private val disposable = CompositeDisposable()
 
     private val _subscriptionList = ArrayList<String>()
@@ -48,15 +50,14 @@ class SettingNotificationViewModel @Inject constructor(
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
             if(!task.isSuccessful) {
                 Timber.e("Firebase instanceId fail : ${task.exception}")
-                analytics.errorEvent("${task.exception}", "SettingNotificationActivity")
+                analytics.errorEvent("${task.exception}", className)
             }
-            fcmToken = task.result
-            if (fcmToken == null) {
+            else if (task.result == null) {
                 Timber.e("Fcm Token is null")
-                analytics.errorEvent("Fcm Token is null!", "SettingNotificationActivity")
+                analytics.errorEvent("Fcm Token is null!", className)
+            } else {
+                syncWithServer()
             }
-
-            syncWithServer()
         }
     }
 
@@ -191,5 +192,9 @@ class SettingNotificationViewModel @Inject constructor(
         override fun compare(a: String, b: String): Int {
             return getPriority(a) - getPriority(b)
         }
+    }
+
+    companion object {
+        const val className = "SettingNotificationViewModel"
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/setting_notification/SettingNotificationViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/setting_notification/SettingNotificationViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.google.firebase.messaging.FirebaseMessaging
+import com.ku_stacks.ku_ring.analytics.EventAnalytics
 import com.ku_stacks.ku_ring.data.api.request.SubscribeRequest
 import com.ku_stacks.ku_ring.repository.SubscribeRepository
-import com.ku_stacks.ku_ring.repository.SubscribeRepositoryImpl
 import com.ku_stacks.ku_ring.util.PreferenceUtil
 import com.ku_stacks.ku_ring.util.WordConverter
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,7 +20,8 @@ import kotlin.Comparator
 @HiltViewModel
 class SettingNotificationViewModel @Inject constructor(
     private val repository: SubscribeRepository,
-    private val pref: PreferenceUtil
+    private val pref: PreferenceUtil,
+    private val analytics: EventAnalytics
 ) : ViewModel(){
     private val disposable = CompositeDisposable()
 
@@ -45,13 +46,14 @@ class SettingNotificationViewModel @Inject constructor(
 
     init {
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
-            if(!task.isSuccessful){
+            if(!task.isSuccessful) {
                 Timber.e("Firebase instanceId fail : ${task.exception}")
-                throw RuntimeException("Failed to get Fcm Token error, exception : ${task.exception}")
+                analytics.errorEvent("${task.exception}", "SettingNotificationActivity")
             }
             fcmToken = task.result
             if (fcmToken == null) {
-                throw RuntimeException("Fcm Token is null!")
+                Timber.e("Fcm Token is null")
+                analytics.errorEvent("Fcm Token is null!", "SettingNotificationActivity")
             }
 
             syncWithServer()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="feedback_success">피드백이 정상적으로 전송되었습니다</string>
     <string name="feedback_write_more_character">5글자 이상 입력해주세요</string>
     <string name="feedback_size_of_character">글자수 : %s/256</string>
+    <string name="feedback_cannot_send">피드백을 보낼 수 없습니다. fcm 토큰을 확인해주세요</string>
 
     <!--  open source  -->
     <string name="open_source">오픈소스</string>


### PR DESCRIPTION
### 배경
- fcm token을 가져오지 못하면 throw Exception 하여 Crashlytics에 전송되도록 했었다.
- 일반 사용자들에게는 이슈가 되지 않지만 플레이스토어 업데이트 요청할 때마다 구글 검수측에서 Crash가 발생하였고 앱의 안정성이 문제가 있는것 처럼 보이게 된다.
  - 구글측에서 Crash나는 원인은 한 에뮬레이터 또는 기기에서 너무 많은 fcm registration을 요청하면 발생하는것으로 보인다.
  - 관련 링크 : https://stackoverflow.com/questions/47529977/firebase-token-error-too-many-registrations

### 변경 사항
- EventAnalytics 모듈에서 errorEvent()를 만들어 커스텀 에러 로그를 따로 전송할 수 있도록 하였다.
- FeedbackViewModel, SettingNotificationViewModel에서 fcm token을 가져오지 못하면 crashlytics 대신 analytics로 전송하고, 화면에 Toast 메세지를 보여준다.