### PR TITLE
[리팩토링] 공지 읽음 처리에 대한 책임 위치 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
             android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
             android:theme="@style/OpenSourceItemTheme" />
 
-        <activity android:name=".ui.detail.DetailActivity" />
+        <activity android:name=".ui.notice_webview.NoticeActivity" />
 
         <activity android:name=".ui.setting_notification.SettingNotificationActivity"
             android:screenOrientation="portrait"

--- a/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
@@ -13,7 +13,6 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.ku_stacks.ku_ring.data.db.PushDao
 import com.ku_stacks.ku_ring.data.db.PushEntity
-import com.ku_stacks.ku_ring.ui.detail.DetailActivity
 import com.ku_stacks.ku_ring.ui.home.HomeActivity
 import com.ku_stacks.ku_ring.util.DateUtil
 import com.ku_stacks.ku_ring.util.UrlGenerator

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
@@ -15,7 +15,7 @@ interface NoticeDao {
     fun getOldNoticeList(): Single<List<NoticeEntity>>
 
     @Query("SELECT articleId FROM NoticeEntity WHERE isRead = :value")
-    fun getReadNoticeRecord(value: Boolean): Flowable<List<String>>
+    fun getReadNoticeList(value: Boolean): Flowable<List<String>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun updateNotice(notice: NoticeEntity): Completable

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
@@ -21,10 +21,10 @@ interface NoticeDao {
     fun updateNotice(notice: NoticeEntity): Completable
 
     @Query("SELECT COUNT(*) FROM NoticeEntity WHERE isRead = :value and articleId = :id")
-    fun getCountForReadNotice(value: Boolean, id: String): Single<Int>
+    fun getCountOfReadNotice(value: Boolean, id: String): Single<Int>
 
     fun isReadNotice(id: String): Boolean {
-        return getCountForReadNotice(true, id).subscribeOn(Schedulers.io()).blockingGet() > 0
+        return getCountOfReadNotice(true, id).subscribeOn(Schedulers.io()).blockingGet() > 0
     }
 
     //not using now

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
@@ -12,7 +12,7 @@ interface NoticeDao {
     fun insertNoticeAsOld(notice: NoticeEntity): Completable
 
     @Query("SELECT * FROM NoticeEntity")
-    fun getNoticeRecord(): Single<List<NoticeEntity>>
+    fun getOldNoticeList(): Single<List<NoticeEntity>>
 
     @Query("SELECT articleId FROM NoticeEntity WHERE isRead = :value")
     fun getReadNoticeRecord(value: Boolean): Flowable<List<String>>

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/NoticeDao.kt
@@ -9,7 +9,7 @@ import io.reactivex.rxjava3.schedulers.Schedulers
 @Dao
 interface NoticeDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun insertNotice(notice: NoticeEntity): Completable
+    fun insertNoticeAsOld(notice: NoticeEntity): Completable
 
     @Query("SELECT * FROM NoticeEntity")
     fun getNoticeRecord(): Single<List<NoticeEntity>>

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/db/PushDao.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/db/PushDao.kt
@@ -13,7 +13,7 @@ interface PushDao {
     fun updateNotificationAsOld(articleId: String, value: Boolean): Completable
 
     @Query("SELECT * FROM PushEntity ORDER BY postedDate DESC, receivedDate DESC")
-    fun getNotification(): Flowable<List<PushEntity>>
+    fun getNotificationList(): Flowable<List<PushEntity>>
 
     @Query("SELECT COUNT(articleId) FROM PushEntity WHERE isNew = :value")
     fun getNotificationCount(value: Boolean): Flowable<Int>

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/NoticeRepository.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/NoticeRepository.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 
 interface NoticeRepository {
     fun getNotices(type: String, scope: CoroutineScope): Flowable<PagingData<Notice>>
-    fun insertNotice(articleId: String, category: String): Completable
+    fun insertNoticeAsOld(articleId: String, category: String): Completable
     fun updateNoticeToBeRead(articleId: String, category: String): Completable
     fun deleteAllNoticeRecord()
     fun deleteSharedPreference()

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryImpl.kt
@@ -108,8 +108,8 @@ class NoticeRepositoryImpl @Inject constructor(
         ).flowable
     }
 
-    override fun insertNotice(articleId: String, category: String): Completable {
-        return noticeDao.insertNotice(
+    override fun insertNoticeAsOld(articleId: String, category: String): Completable {
+        return noticeDao.insertNoticeAsOld(
             NoticeEntity(
                 articleId = articleId,
                 category = category,

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryImpl.kt
@@ -34,7 +34,7 @@ class NoticeRepositoryImpl @Inject constructor(
          하나의 insert에 대해서 2개 또는 3개의 변화 감지가 발생할 것임.
          그 이유는 양옆 fragment 의 viewModel 에서 호출하기 때문
         */
-        val flowableLocal = noticeDao.getReadNoticeRecord(true)
+        val flowableLocal = noticeDao.getReadNoticeList(true)
             .distinctUntilChanged { old, new ->
                 /**
                  DB insert 되는 경우, 업데이트를 감지하기 위함이므로 성능을 위해

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryImpl.kt
@@ -25,7 +25,7 @@ class NoticeRepositoryImpl @Inject constructor(
     private val isNewRecordHashMap = HashMap<String, NoticeEntity>()
 
     override fun getNotices(type: String, scope: CoroutineScope): Flowable<PagingData<Notice>> {
-        val flowableRemote = getSingleLocal()
+        val flowableRemote = getSingleLocalNotice()
             .flatMap { getFlowableRemoteNotice(type) }
             .map { transformRemoteData(it, type) }
             .cachedIn(scope)
@@ -85,8 +85,8 @@ class NoticeRepositoryImpl @Inject constructor(
         }
     }
 
-    private fun getSingleLocal(): Flowable<List<NoticeEntity>> {
-        return noticeDao.getNoticeRecord()
+    private fun getSingleLocalNotice(): Flowable<List<NoticeEntity>> {
+        return noticeDao.getOldNoticeList()
             .subscribeOn(Schedulers.io())
             .toFlowable()
             .doOnNext { // local 데이터가 처음 발행될때 HashMap 에 저장 (단 한번만 실행)

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/PushRepository.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/PushRepository.kt
@@ -5,7 +5,7 @@ import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
 
 interface PushRepository {
-    fun getMyNotification(): Flowable<List<Push>>
+    fun getMyNotificationList(): Flowable<List<Push>>
     fun updateNotificationAsOld(articleId: String): Completable
     fun getNotificationCount(): Flowable<Int>
     fun deleteNotification(articleId: String)

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/PushRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/PushRepositoryImpl.kt
@@ -11,8 +11,8 @@ import javax.inject.Inject
 class PushRepositoryImpl @Inject constructor(
     private val dao: PushDao
 ) : PushRepository {
-    override fun getMyNotification(): Flowable<List<Push>> {
-        return dao.getNotification()
+    override fun getMyNotificationList(): Flowable<List<Push>> {
+        return dao.getNotificationList()
             .distinctUntilChanged()
             .map { pushEntityList -> pushEntityList.toPushList() }
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeActivity.kt
@@ -63,7 +63,7 @@ class HomeActivity : AppCompatActivity() {
         intent?.getStringExtra(NoticeActivity.NOTICE_URL)?.let {
             val articleId = intent.getStringExtra(NoticeActivity.NOTICE_ARTICLE_ID)
             val category = intent.getStringExtra(NoticeActivity.NOTICE_CATEGORY)
-            navToDetailActivity(it, articleId, category)
+            navToNoticeActivity(it, articleId, category)
         }
 
         setupBinding()
@@ -161,11 +161,11 @@ class HomeActivity : AppCompatActivity() {
         intent?.getStringExtra(NoticeActivity.NOTICE_URL)?.let {
             val articleId = intent.getStringExtra(NoticeActivity.NOTICE_ARTICLE_ID)
             val category = intent.getStringExtra(NoticeActivity.NOTICE_CATEGORY)
-            navToDetailActivity(it, articleId, category)
+            navToNoticeActivity(it, articleId, category)
         }
     }
 
-    private fun navToDetailActivity(noticeUrl: String?, articleId: String?, category: String?) {
+    private fun navToNoticeActivity(noticeUrl: String?, articleId: String?, category: String?) {
         val newIntent = Intent(this, NoticeActivity::class.java).apply {
             putExtra(NoticeActivity.NOTICE_URL, noticeUrl)
             putExtra(NoticeActivity.NOTICE_ARTICLE_ID, articleId)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeActivity.kt
@@ -60,8 +60,10 @@ class HomeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        intent?.getStringExtra(NOTICE_URL)?.let {
-            navToDetailActivity(it)
+        intent?.getStringExtra(NoticeActivity.NOTICE_URL)?.let {
+            val articleId = intent.getStringExtra(NoticeActivity.NOTICE_ARTICLE_ID)
+            val category = intent.getStringExtra(NoticeActivity.NOTICE_CATEGORY)
+            navToDetailActivity(it, articleId, category)
         }
 
         setupBinding()
@@ -160,14 +162,19 @@ class HomeActivity : AppCompatActivity() {
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
 
-        intent?.getStringExtra(NOTICE_URL)?.let {
-            navToDetailActivity(it)
+        intent?.getStringExtra(NoticeActivity.NOTICE_URL)?.let {
+            val articleId = intent.getStringExtra(NoticeActivity.NOTICE_ARTICLE_ID)
+            val category = intent.getStringExtra(NoticeActivity.NOTICE_CATEGORY)
+            navToDetailActivity(it, articleId, category)
         }
     }
 
-    private fun navToDetailActivity(noticeUrl: String?) {
-        val newIntent = Intent(this, NoticeActivity::class.java)
-        newIntent.putExtra("url", noticeUrl)
+    private fun navToDetailActivity(noticeUrl: String?, articleId: String?, category: String?) {
+        val newIntent = Intent(this, NoticeActivity::class.java).apply {
+            putExtra(NoticeActivity.NOTICE_URL, noticeUrl)
+            putExtra(NoticeActivity.NOTICE_ARTICLE_ID, articleId)
+            putExtra(NoticeActivity.NOTICE_CATEGORY, category)
+        }
         startActivity(newIntent)
         overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
     }
@@ -184,9 +191,5 @@ class HomeActivity : AppCompatActivity() {
             showToast(getString(R.string.home_finish_if_back_again))
             backPressedTime = System.currentTimeMillis()
         }
-    }
-
-    companion object {
-        const val NOTICE_URL = "NOTICE_URL"
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeActivity.kt
@@ -9,13 +9,11 @@ import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayoutMediator
-import com.google.firebase.installations.FirebaseInstallations
 import com.google.firebase.messaging.FirebaseMessaging
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.analytics.EventAnalytics
-import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.databinding.ActivityHomeBinding
-import com.ku_stacks.ku_ring.ui.detail.DetailActivity
+import com.ku_stacks.ku_ring.ui.notice_webview.NoticeActivity
 import com.ku_stacks.ku_ring.ui.home.dialog.HomeBottomSheet
 import com.ku_stacks.ku_ring.ui.my_notification.NotificationActivity
 import com.ku_stacks.ku_ring.ui.search.SearchActivity
@@ -155,10 +153,6 @@ class HomeActivity : AppCompatActivity() {
         bottomSheet.show(supportFragmentManager, bottomSheet.tag)
     }
 
-    fun updateNoticeTobeRead(notice: Notice) {
-        viewModel.updateNoticeTobeRead(notice)
-    }
-
     fun insertNotice(articleId: String, category: String) {
         viewModel.insertNotice(articleId, category)
     }
@@ -172,7 +166,7 @@ class HomeActivity : AppCompatActivity() {
     }
 
     private fun navToDetailActivity(noticeUrl: String?) {
-        val newIntent = Intent(this, DetailActivity::class.java)
+        val newIntent = Intent(this, NoticeActivity::class.java)
         newIntent.putExtra("url", noticeUrl)
         startActivity(newIntent)
         overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeActivity.kt
@@ -155,10 +155,6 @@ class HomeActivity : AppCompatActivity() {
         bottomSheet.show(supportFragmentManager, bottomSheet.tag)
     }
 
-    fun insertNotice(articleId: String, category: String) {
-        viewModel.insertNotice(articleId, category)
-    }
-
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeViewModel.kt
@@ -34,16 +34,6 @@ class HomeViewModel @Inject constructor(
         getNotificationCount()
     }
 
-    fun updateNoticeTobeRead(notice: Notice) {
-        disposable.add(
-            noticeRepository.updateNoticeToBeRead(notice.articleId, notice.category)
-                .subscribeOn(Schedulers.io())
-                .subscribe({
-                    //Timber.e("noticeRecord update true : $articleId")
-                }, { Timber.e("noticeRecord update fail") })
-        )
-    }
-
     fun insertNotice(articleId: String, category: String) {
         disposable.add(
             noticeRepository.insertNotice(articleId = articleId, category = category)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/HomeViewModel.kt
@@ -3,7 +3,6 @@ package com.ku_stacks.ku_ring.ui.home
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.repository.NoticeRepository
 import com.ku_stacks.ku_ring.repository.PushRepository
 import com.ku_stacks.ku_ring.ui.home.nav.HomeTabState
@@ -34,9 +33,9 @@ class HomeViewModel @Inject constructor(
         getNotificationCount()
     }
 
-    fun insertNotice(articleId: String, category: String) {
+    fun insertNoticeAsOld(articleId: String, category: String) {
         disposable.add(
-            noticeRepository.insertNotice(articleId = articleId, category = category)
+            noticeRepository.insertNoticeAsOld(articleId = articleId, category = category)
                 .subscribeOn(Schedulers.io())
                 .subscribe({
                     //Timber.e("noticeRecord Insert true : $articleId")

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/category/HomeBaseFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/category/HomeBaseFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.paging.LoadState
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -15,6 +16,7 @@ import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.databinding.FragmentHomeCategoryBinding
 import com.ku_stacks.ku_ring.ui.notice_webview.NoticeActivity
 import com.ku_stacks.ku_ring.ui.home.HomeActivity
+import com.ku_stacks.ku_ring.ui.home.HomeViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -24,6 +26,8 @@ abstract class HomeBaseFragment : Fragment() {
 
     protected lateinit var binding: FragmentHomeCategoryBinding
     protected lateinit var pagingAdapter: NoticePagingAdapter
+
+    private val homeViewModel by activityViewModels<HomeViewModel>()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_home_category, container,false)
@@ -63,7 +67,7 @@ abstract class HomeBaseFragment : Fragment() {
                 startDetailActivity(notice)
             },
             onBindItem = { notice ->
-                (activity as HomeActivity).insertNotice(notice.articleId, notice.category)
+                homeViewModel.insertNotice(notice.articleId, notice.category)
             }
         )
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/category/HomeBaseFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/category/HomeBaseFragment.kt
@@ -95,9 +95,9 @@ abstract class HomeBaseFragment : Fragment() {
 
     private fun startDetailActivity(notice: Notice) {
         val intent = Intent(requireActivity(), NoticeActivity::class.java).apply {
-            putExtra("url", notice.url)
-            putExtra("articleId", notice.articleId)
-            putExtra("category", notice.category)
+            putExtra(NoticeActivity.NOTICE_URL, notice.url)
+            putExtra(NoticeActivity.NOTICE_ARTICLE_ID, notice.articleId)
+            putExtra(NoticeActivity.NOTICE_CATEGORY, notice.category)
         }
         startActivity(intent)
         requireActivity().overridePendingTransition(

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/category/HomeBaseFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/category/HomeBaseFragment.kt
@@ -13,7 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.databinding.FragmentHomeCategoryBinding
-import com.ku_stacks.ku_ring.ui.detail.DetailActivity
+import com.ku_stacks.ku_ring.ui.notice_webview.NoticeActivity
 import com.ku_stacks.ku_ring.ui.home.HomeActivity
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import kotlinx.coroutines.flow.collectLatest
@@ -60,7 +60,6 @@ abstract class HomeBaseFragment : Fragment() {
     private fun setupListAdapter() {
         pagingAdapter = NoticePagingAdapter(
             itemClick = { notice ->
-                (activity as HomeActivity).updateNoticeTobeRead(notice)
                 startDetailActivity(notice)
             },
             onBindItem = { notice ->
@@ -95,8 +94,11 @@ abstract class HomeBaseFragment : Fragment() {
     }
 
     private fun startDetailActivity(notice: Notice) {
-        val intent = Intent(requireActivity(), DetailActivity::class.java)
-        intent.putExtra("url", notice.url)
+        val intent = Intent(requireActivity(), NoticeActivity::class.java).apply {
+            putExtra("url", notice.url)
+            putExtra("articleId", notice.articleId)
+            putExtra("category", notice.category)
+        }
         startActivity(intent)
         requireActivity().overridePendingTransition(
             R.anim.anim_slide_right_enter,

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/category/HomeBaseFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/category/HomeBaseFragment.kt
@@ -15,7 +15,6 @@ import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.databinding.FragmentHomeCategoryBinding
 import com.ku_stacks.ku_ring.ui.notice_webview.NoticeActivity
-import com.ku_stacks.ku_ring.ui.home.HomeActivity
 import com.ku_stacks.ku_ring.ui.home.HomeViewModel
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import kotlinx.coroutines.flow.collectLatest
@@ -64,7 +63,7 @@ abstract class HomeBaseFragment : Fragment() {
     private fun setupListAdapter() {
         pagingAdapter = NoticePagingAdapter(
             itemClick = { notice ->
-                startDetailActivity(notice)
+                startNoticeActivity(notice)
             },
             onBindItem = { notice ->
                 homeViewModel.insertNotice(notice.articleId, notice.category)
@@ -97,7 +96,7 @@ abstract class HomeBaseFragment : Fragment() {
         binding.homeShimmerLayout.visibility = View.GONE
     }
 
-    private fun startDetailActivity(notice: Notice) {
+    private fun startNoticeActivity(notice: Notice) {
         val intent = Intent(requireActivity(), NoticeActivity::class.java).apply {
             putExtra(NoticeActivity.NOTICE_URL, notice.url)
             putExtra(NoticeActivity.NOTICE_ARTICLE_ID, notice.articleId)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/category/HomeBaseFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/category/HomeBaseFragment.kt
@@ -66,7 +66,7 @@ abstract class HomeBaseFragment : Fragment() {
                 startNoticeActivity(notice)
             },
             onBindItem = { notice ->
-                homeViewModel.insertNotice(notice.articleId, notice.category)
+                homeViewModel.insertNoticeAsOld(notice.articleId, notice.category)
             }
         )
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/home/dialog/HomeBottomSheet.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/home/dialog/HomeBottomSheet.kt
@@ -57,7 +57,7 @@ class HomeBottomSheet: BottomSheetDialogFragment() {
         analytics.click("bottomSheet_NewContents btn", "HomeActivity")
 
         val intent = Intent(activity, NotionViewActivity::class.java)
-        intent.putExtra("url", getString(R.string.notion_new_contents_url))
+        intent.putExtra(NotionViewActivity.NOTION_URL, getString(R.string.notion_new_contents_url))
         startActivity(intent)
         dialog?.dismiss()
     }
@@ -82,7 +82,7 @@ class HomeBottomSheet: BottomSheetDialogFragment() {
         analytics.click("bottomSheet_PersonalInformation btn", "HomeActivity")
 
         val intent = Intent(activity, NotionViewActivity::class.java)
-        intent.putExtra("url", getString(R.string.notion_personal_data_url))
+        intent.putExtra(NotionViewActivity.NOTION_URL, getString(R.string.notion_personal_data_url))
         startActivity(intent)
         dialog?.dismiss()
     }
@@ -91,7 +91,7 @@ class HomeBottomSheet: BottomSheetDialogFragment() {
         analytics.click("bottomSheet_TermsOfService btn", "HomeActivity")
 
         val intent = Intent(activity, NotionViewActivity::class.java)
-        intent.putExtra("url", getString(R.string.notion_terms_of_service_url))
+        intent.putExtra(NotionViewActivity.NOTION_URL, getString(R.string.notion_terms_of_service_url))
         startActivity(intent)
         dialog?.dismiss()
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
@@ -69,7 +69,7 @@ class NotificationActivity : AppCompatActivity() {
     private fun setupListAdapter() {
         notificationAdapter = NotificationAdapter(
             itemClick = {
-                startDetailActivity(it.articleId, it.baseUrl, it.category)
+                startNoticeActivity(it.articleId, it.baseUrl, it.category)
             },
             onBindItem = {
                 viewModel.updateNotificationToBeOld(it.articleId)
@@ -122,7 +122,7 @@ class NotificationActivity : AppCompatActivity() {
         }
     }
 
-    private fun startDetailActivity(articleId: String, baseUrl: String, category: String) {
+    private fun startNoticeActivity(articleId: String, baseUrl: String, category: String) {
         val url = UrlGenerator.generateNoticeUrl(articleId, category, baseUrl)
         Timber.e("url : $url, category : $category")
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
@@ -40,7 +40,7 @@ class NotificationActivity : AppCompatActivity() {
         setupListAdapter()
         observeData()
 
-        viewModel.getMyNotification()
+        viewModel.getMyNotificationList()
     }
 
     private fun setupBinding() {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
@@ -11,7 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.analytics.EventAnalytics
 import com.ku_stacks.ku_ring.databinding.ActivityNotificationBinding
-import com.ku_stacks.ku_ring.ui.detail.DetailActivity
+import com.ku_stacks.ku_ring.ui.notice_webview.NoticeActivity
 import com.ku_stacks.ku_ring.ui.home.HomeActivity
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushContentUiModel
 import com.ku_stacks.ku_ring.ui.setting_notification.SettingNotificationActivity
@@ -69,7 +69,6 @@ class NotificationActivity : AppCompatActivity() {
     private fun setupListAdapter() {
         notificationAdapter = NotificationAdapter(
             itemClick = {
-                viewModel.updateNoticeTobeRead(it.articleId, it.category)
                 startDetailActivity(it.articleId, it.baseUrl, it.category)
             },
             onBindItem = {
@@ -127,8 +126,11 @@ class NotificationActivity : AppCompatActivity() {
         val url = UrlGenerator.generateNoticeUrl(articleId, category, baseUrl)
         Timber.e("url : $url, category : $category")
 
-        val intent = Intent(this, DetailActivity::class.java)
-        intent.putExtra("url", url)
+        val intent = Intent(this, NoticeActivity::class.java).apply {
+            putExtra("url", url)
+            putExtra("articleId", articleId)
+            putExtra("category", category)
+        }
         startActivity(intent)
         overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
@@ -127,9 +127,9 @@ class NotificationActivity : AppCompatActivity() {
         Timber.e("url : $url, category : $category")
 
         val intent = Intent(this, NoticeActivity::class.java).apply {
-            putExtra("url", url)
-            putExtra("articleId", articleId)
-            putExtra("category", category)
+            putExtra(NoticeActivity.NOTICE_URL, url)
+            putExtra(NoticeActivity.NOTICE_ARTICLE_ID, articleId)
+            putExtra(NoticeActivity.NOTICE_CATEGORY, category)
         }
         startActivity(intent)
         overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationViewModel.kt
@@ -66,16 +66,6 @@ class NotificationViewModel @Inject constructor(
         pushRepository.deleteAllNotification()
     }
 
-    fun updateNoticeTobeRead(articleId: String, category: String) {
-        disposable.add(
-            noticeRepository.updateNoticeToBeRead(articleId, category)
-                .subscribeOn(Schedulers.io())
-                .subscribe({
-                    Timber.e("noticeRecord update true : $category")
-                }, { Timber.e("noticeRecord update fail") })
-        )
-    }
-
     override fun onCleared() {
         super.onCleared()
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationViewModel.kt
@@ -27,9 +27,9 @@ class NotificationViewModel @Inject constructor(
     val pushUiModelList: LiveData<List<PushDataUiModel>>
         get() = _pushUiModelList
 
-    fun getMyNotification() {
+    fun getMyNotificationList() {
         disposable.add(
-            pushRepository.getMyNotification()
+            pushRepository.getMyNotificationList()
                 .subscribeOn(Schedulers.io())
                 .map { pushList -> pushList.toPushUiModelList() }
                 .subscribe({

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.ku_stacks.ku_ring.data.mapper.toPushUiModelList
-import com.ku_stacks.ku_ring.repository.NoticeRepository
 import com.ku_stacks.ku_ring.repository.PushRepository
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushDataUiModel
 import com.ku_stacks.ku_ring.util.PreferenceUtil
@@ -17,7 +16,6 @@ import javax.inject.Inject
 @HiltViewModel
 class NotificationViewModel @Inject constructor(
     private val pushRepository: PushRepository,
-    private val noticeRepository: NoticeRepository,
     private val pref: PreferenceUtil
 ) : ViewModel() {
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeActivity.kt
@@ -23,16 +23,16 @@ class NoticeActivity : AppCompatActivity() {
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_detail)
+        setContentView(R.layout.activity_notice)
 
-        webView = findViewById(R.id.detail_webView)
-        progressBar = findViewById(R.id.detail_progressbar)
+        webView = findViewById(R.id.notice_webView)
+        progressBar = findViewById(R.id.notice_progressbar)
 
         val url = intent.getStringExtra(NOTICE_URL)
         val articleId = intent.getStringExtra(NOTICE_ARTICLE_ID)
         val category = intent.getStringExtra(NOTICE_CATEGORY)
 
-        Timber.e("detail url : $url")
+        Timber.e("notice url : $url")
 
         webView.webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeActivity.kt
@@ -25,14 +25,14 @@ class NoticeActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_detail)
 
-        val url = intent.getStringExtra("url")
-        val articleId = intent.getStringExtra("articleId")
-        val category = intent.getStringExtra("category")
-
-        Timber.e("detail url : $url")
-
         webView = findViewById(R.id.detail_webView)
         progressBar = findViewById(R.id.detail_progressbar)
+
+        val url = intent.getStringExtra(NOTICE_URL)
+        val articleId = intent.getStringExtra(NOTICE_ARTICLE_ID)
+        val category = intent.getStringExtra(NOTICE_CATEGORY)
+
+        Timber.e("detail url : $url")
 
         webView.webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(
@@ -62,6 +62,7 @@ class NoticeActivity : AppCompatActivity() {
                 if (newProgress == 100) {
                     progressBar.visibility = View.GONE
                     updateNoticeTobeRead(articleId, category)
+                    webView.webChromeClient = null
                 } else {
                     progressBar.visibility = View.VISIBLE
                 }
@@ -85,5 +86,11 @@ class NoticeActivity : AppCompatActivity() {
     override fun onBackPressed() {
         super.onBackPressed()
         overridePendingTransition(R.anim.anim_slide_left_enter, R.anim.anim_slide_left_exit)
+    }
+
+    companion object {
+        const val NOTICE_URL = "url"
+        const val NOTICE_ARTICLE_ID = "articleId"
+        const val NOTICE_CATEGORY = "category"
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeActivity.kt
@@ -1,4 +1,4 @@
-package com.ku_stacks.ku_ring.ui.detail
+package com.ku_stacks.ku_ring.ui.notice_webview
 
 import android.annotation.SuppressLint
 import android.content.Intent
@@ -6,26 +6,16 @@ import android.os.Bundle
 import android.view.View
 import android.webkit.*
 import android.widget.ProgressBar
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.ku_stacks.ku_ring.R
+import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
-/*
-    javaScriptEnabled = true // 웹페이지 자바스크립트 허용 여부
-    setSupportMultipleWindows(false) // 새창 띄우기 허용 여부
-    javaScriptCanOpenWindowsAutomatically = false // 자바스크립트 새창 띄우기(멀티뷰) 허용 여부
-    loadWithOverviewMode = true // 메타태그 허용 여부
-    useWideViewPort = false // 화면 사이즈 맞추기 허용 여부(true로 두면 pc화면 처럼 보임)
-    setSupportZoom(false) // 화면 줌 허용 여부
-    displayZoomControls = false // 화면 줌 허용할 때 돋보기 보임 여부
-    builtInZoomControls = true // 화면 확대 축소 허용 여부 (true로 두면 돋보기+- 버튼 생김)
-    layoutAlgorithm = WebSettings.LayoutAlgorithm.SINGLE_COLUMN // 컨텐츠 사이즈 맞추기
-    cacheMode = WebSettings.LOAD_CACHE_ELSE_NETWORK // 브라우저 캐시 허용 여부
-    domStorageEnabled = true // 로컬저장소 허용 여부
-위의 설정으로 하면 일부 안열리는 링크가 있었음 ex. 예술문화관(능동로 방향) 펜스 출입문 통제 안내
- */
+@AndroidEntryPoint
+class NoticeActivity : AppCompatActivity() {
 
-class DetailActivity : AppCompatActivity() {
+    private val viewModel by viewModels<NoticeViewModel>()
 
     private lateinit var webView: WebView
     private lateinit var progressBar: ProgressBar
@@ -36,6 +26,9 @@ class DetailActivity : AppCompatActivity() {
         setContentView(R.layout.activity_detail)
 
         val url = intent.getStringExtra("url")
+        val articleId = intent.getStringExtra("articleId")
+        val category = intent.getStringExtra("category")
+
         Timber.e("detail url : $url")
 
         webView = findViewById(R.id.detail_webView)
@@ -66,13 +59,26 @@ class DetailActivity : AppCompatActivity() {
         webView.webChromeClient = object : WebChromeClient() {
             override fun onProgressChanged(view: WebView, newProgress: Int) {
                 progressBar.progress = newProgress
-                progressBar.visibility = if (newProgress == 100) View.GONE else View.VISIBLE
+                if (newProgress == 100) {
+                    progressBar.visibility = View.GONE
+                    updateNoticeTobeRead(articleId, category)
+                } else {
+                    progressBar.visibility = View.VISIBLE
+                }
                 super.onProgressChanged(view, newProgress)
             }
         }
 
         url?.let {
             webView.loadUrl(it) //웹뷰에 표시할 웹사이트 주소, 웹뷰 시작
+        }
+    }
+
+    private fun updateNoticeTobeRead(articleId: String?, category: String?) {
+        if (articleId.isNullOrEmpty() || category.isNullOrEmpty()) {
+            Timber.e("articleId or category is null. articleId : $articleId, category : $category")
+        } else {
+            viewModel.updateNoticeTobeRead(articleId, category)
         }
     }
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeViewModel.kt
@@ -1,0 +1,37 @@
+package com.ku_stacks.ku_ring.ui.notice_webview
+
+import androidx.lifecycle.ViewModel
+import com.ku_stacks.ku_ring.repository.NoticeRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.schedulers.Schedulers
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class NoticeViewModel @Inject constructor(
+    private val repository: NoticeRepository
+) : ViewModel() {
+
+    private val disposable = CompositeDisposable()
+
+    fun updateNoticeTobeRead(articleId: String, category: String) {
+        disposable.add(
+            repository.updateNoticeToBeRead(articleId, category)
+                .subscribeOn(Schedulers.io())
+                .subscribe({
+                    Timber.e("noticeRecord update true : $articleId")
+                }, {
+                    Timber.e("noticeRecord update fail : $it")
+                })
+        )
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+
+        if (!disposable.isDisposed) {
+            disposable.dispose()
+        }
+    }
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notion/NotionViewActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notion/NotionViewActivity.kt
@@ -16,7 +16,7 @@ class NotionViewActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_personal_data)
 
-        val url = intent.getStringExtra("url")
+        val url = intent.getStringExtra(NOTION_URL)
 
         val webView = findViewById<WebView>(R.id.personal_data_webview)
         val progressBar = findViewById<ProgressBar>(R.id.personal_data_progressbar)
@@ -40,5 +40,9 @@ class NotionViewActivity : AppCompatActivity() {
         url?.let {
             webView.loadUrl(it)
         }
+    }
+
+    companion object {
+        const val NOTION_URL = "notion_url"
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/on_boarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/on_boarding/OnBoardingActivity.kt
@@ -39,7 +39,7 @@ class OnBoardingActivity : AppCompatActivity() {
 
         subscribeNoticeButton.setOnClickListener {
             val intent = Intent(this, SettingNotificationActivity::class.java).apply {
-                putExtra("firstRunFlag", true)
+                putExtra(SettingNotificationActivity.FIRST_RUN_FLAG, true)
             }
             getOnBoardingFinishResult.launch(intent)
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/search/SearchViewModel.kt
@@ -133,16 +133,6 @@ class SearchViewModel @Inject constructor(
         )
     }
 
-    fun updateNoticeTobeRead(notice: Notice) {
-        disposable.add(
-            noticeRepository.updateNoticeToBeRead(notice.articleId, notice.category)
-                .subscribeOn(Schedulers.io())
-                .subscribe({
-                    //Timber.e("noticeRecord update true : $category")
-                }, { Timber.e("noticeRecord update fail") })
-        )
-    }
-
     override fun onCleared() {
         super.onCleared()
         disconnectWebSocket()

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/search/fragment_notice/SearchNoticeFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/search/fragment_notice/SearchNoticeFragment.kt
@@ -12,7 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.databinding.FragmentSearchNoticeBinding
-import com.ku_stacks.ku_ring.ui.detail.DetailActivity
+import com.ku_stacks.ku_ring.ui.notice_webview.NoticeActivity
 import com.ku_stacks.ku_ring.ui.search.SearchActivity
 import com.ku_stacks.ku_ring.ui.search.SearchViewModel
 
@@ -36,10 +36,9 @@ class SearchNoticeFragment: Fragment() {
     }
 
     private fun setupListAdapter() {
-        searchNoticeAdapter = SearchNoticeAdapter {
-            searchViewModel.updateNoticeTobeRead(it)
-            startDetailActivity(it)
-        }
+        searchNoticeAdapter = SearchNoticeAdapter(
+            itemClick = { startDetailActivity(it) }
+        )
         binding.searchNoticeRecyclerview.layoutManager = LinearLayoutManager(activity)
         binding.searchNoticeRecyclerview.adapter = searchNoticeAdapter
     }
@@ -56,8 +55,11 @@ class SearchNoticeFragment: Fragment() {
     }
 
     private fun startDetailActivity(notice: Notice) {
-        val intent = Intent(requireContext(), DetailActivity::class.java)
-        intent.putExtra("url", notice.url)
+        val intent = Intent(requireContext(), NoticeActivity::class.java).apply {
+            putExtra("url", notice.url)
+            putExtra("articleId", notice.articleId)
+            putExtra("category", notice.category)
+        }
         startActivity(intent)
         requireActivity().overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/search/fragment_notice/SearchNoticeFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/search/fragment_notice/SearchNoticeFragment.kt
@@ -37,7 +37,9 @@ class SearchNoticeFragment: Fragment() {
 
     private fun setupListAdapter() {
         searchNoticeAdapter = SearchNoticeAdapter(
-            itemClick = { startDetailActivity(it) }
+            itemClick = {
+                startNoticeActivity(it)
+            }
         )
         binding.searchNoticeRecyclerview.layoutManager = LinearLayoutManager(activity)
         binding.searchNoticeRecyclerview.adapter = searchNoticeAdapter
@@ -54,7 +56,7 @@ class SearchNoticeFragment: Fragment() {
         }
     }
 
-    private fun startDetailActivity(notice: Notice) {
+    private fun startNoticeActivity(notice: Notice) {
         val intent = Intent(requireContext(), NoticeActivity::class.java).apply {
             putExtra(NoticeActivity.NOTICE_URL, notice.url)
             putExtra(NoticeActivity.NOTICE_ARTICLE_ID, notice.articleId)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/search/fragment_notice/SearchNoticeFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/search/fragment_notice/SearchNoticeFragment.kt
@@ -56,9 +56,9 @@ class SearchNoticeFragment: Fragment() {
 
     private fun startDetailActivity(notice: Notice) {
         val intent = Intent(requireContext(), NoticeActivity::class.java).apply {
-            putExtra("url", notice.url)
-            putExtra("articleId", notice.articleId)
-            putExtra("category", notice.category)
+            putExtra(NoticeActivity.NOTICE_URL, notice.url)
+            putExtra(NoticeActivity.NOTICE_ARTICLE_ID, notice.articleId)
+            putExtra(NoticeActivity.NOTICE_CATEGORY, notice.category)
         }
         startActivity(intent)
         requireActivity().overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/setting_notification/SettingNotificationActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/setting_notification/SettingNotificationActivity.kt
@@ -56,7 +56,7 @@ class SettingNotificationActivity : AppCompatActivity() {
     }
 
     private fun setupView() {
-        viewModel.firstRunFlag = intent.getBooleanExtra("firstRunFlag", false)
+        viewModel.firstRunFlag = intent.getBooleanExtra(FIRST_RUN_FLAG, false)
         if(viewModel.firstRunFlag) {
             binding.settingNotificationDismissBt.visibility = View.GONE
             binding.settingNotificationRollbackBt.visibility = View.GONE
@@ -110,5 +110,9 @@ class SettingNotificationActivity : AppCompatActivity() {
     override fun onBackPressed() {
         super.onBackPressed()
         overridePendingTransition(R.anim.anim_slide_left_enter, R.anim.anim_slide_left_exit)
+    }
+
+    companion object {
+        const val FIRST_RUN_FLAG = "firstRunFlag"
     }
 }

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.detail.DetailActivity">
+    tools:context=".ui.notice_webview.NoticeActivity">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/detail_app_bar"

--- a/app/src/main/res/layout/activity_notice.xml
+++ b/app/src/main/res/layout/activity_notice.xml
@@ -7,7 +7,7 @@
     tools:context=".ui.notice_webview.NoticeActivity">
 
     <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/detail_app_bar"
+        android:id="@+id/notice_app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:stateListAnimator="@animator/appbar_elevation">
@@ -46,7 +46,7 @@
             android:layout_height="match_parent">
 
             <ProgressBar
-                android:id="@+id/detail_progressbar"
+                android:id="@+id/notice_progressbar"
                 style="@style/Widget.AppCompat.ProgressBar.Horizontal"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -58,7 +58,7 @@
                 app:layout_constraintVertical_bias="0.0" />
 
             <WebView
-                android:id="@+id/detail_webView"
+                android:id="@+id/notice_webView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:scrollbars="none"

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/NoticeDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/NoticeDaoTest.kt
@@ -68,7 +68,7 @@ class NoticeDaoTest : LocalDbAbstract() {
     }
 
     @Test
-    fun `updateNotice and getCountForReadNoticeTest`() {
+    fun `updateNotice and getCountOfReadNoticeTest`() {
         // given
         val noticeMock = noticeMock()
         noticeDao.insertNoticeAsOld(noticeMock).blockingSubscribe()
@@ -79,7 +79,7 @@ class NoticeDaoTest : LocalDbAbstract() {
 
         // then : insert 후에 isRead 를 true 로 update 하면 읽은 공지 데이터가 1개
         val countForReadNotice =
-            noticeDao.getCountForReadNotice(true, noticeMock.articleId).blockingGet()
+            noticeDao.getCountOfReadNotice(true, noticeMock.articleId).blockingGet()
         assertThat(countForReadNotice, `is`(1))
     }
 

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/NoticeDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/NoticeDaoTest.kt
@@ -98,13 +98,13 @@ class NoticeDaoTest : LocalDbAbstract() {
     }
 
     @Test
-    fun `updateNotice  getReadNoticeRecord Test`() {
+    fun `updateNotice and getReadNoticeList Test`() {
         // given
         val noticeMock = noticeMock()
         noticeDao.insertNoticeAsOld(noticeMock).blockingSubscribe()
 
         // when
-        val sizeOfNotReadNotice = noticeDao.getReadNoticeRecord(true).blockingFirst().size
+        val sizeOfNotReadNotice = noticeDao.getReadNoticeList(true).blockingFirst().size
         // then : 공지를 읽기 전엔 isRead 가 true 인 데이터 0개
         assertThat(sizeOfNotReadNotice, `is`(0))
 
@@ -113,7 +113,7 @@ class NoticeDaoTest : LocalDbAbstract() {
         noticeDao.updateNotice(readNoticeMock).blockingSubscribe()
 
         // when
-        val sizeOfReadNotice = noticeDao.getReadNoticeRecord(true).blockingFirst().size
+        val sizeOfReadNotice = noticeDao.getReadNoticeList(true).blockingFirst().size
         // then : 공지를 읽은 후엔 isRead 가 true 인 데이터 1개
         assertThat(sizeOfReadNotice, `is`(1))
     }

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/NoticeDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/NoticeDaoTest.kt
@@ -42,7 +42,7 @@ class NoticeDaoTest : LocalDbAbstract() {
     fun `insertAndGetNotice Test`() {
         // given
         val noticeMock = noticeMock()
-        noticeDao.insertNotice(noticeMock).blockingSubscribe()
+        noticeDao.insertNoticeAsOld(noticeMock).blockingSubscribe()
 
         // when
         val noticeFromDB = noticeDao.getNoticeRecord().blockingGet()[0]
@@ -55,7 +55,7 @@ class NoticeDaoTest : LocalDbAbstract() {
     fun `updateNotice and getNoticeRecord Test`() {
         // given
         val noticeMock = noticeMock()
-        noticeDao.insertNotice(noticeMock).blockingSubscribe()
+        noticeDao.insertNoticeAsOld(noticeMock).blockingSubscribe()
 
         // when
         val readNoticeMock = readNoticeMock()
@@ -71,7 +71,7 @@ class NoticeDaoTest : LocalDbAbstract() {
     fun `updateNotice and getCountForReadNoticeTest`() {
         // given
         val noticeMock = noticeMock()
-        noticeDao.insertNotice(noticeMock).blockingSubscribe()
+        noticeDao.insertNoticeAsOld(noticeMock).blockingSubscribe()
 
         // when
         val readNoticeMock = readNoticeMock()
@@ -87,7 +87,7 @@ class NoticeDaoTest : LocalDbAbstract() {
     fun `updateNotice and isReadNotice Test`() {
         // given
         val noticeMock = noticeMock()
-        noticeDao.insertNotice(noticeMock).blockingSubscribe()
+        noticeDao.insertNoticeAsOld(noticeMock).blockingSubscribe()
 
         // when
         val readNoticeMock = readNoticeMock()
@@ -101,7 +101,7 @@ class NoticeDaoTest : LocalDbAbstract() {
     fun `updateNotice  getReadNoticeRecord Test`() {
         // given
         val noticeMock = noticeMock()
-        noticeDao.insertNotice(noticeMock).blockingSubscribe()
+        noticeDao.insertNoticeAsOld(noticeMock).blockingSubscribe()
 
         // when
         val sizeOfNotReadNotice = noticeDao.getReadNoticeRecord(true).blockingFirst().size

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/NoticeDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/NoticeDaoTest.kt
@@ -39,20 +39,20 @@ class NoticeDaoTest : LocalDbAbstract() {
     }
 
     @Test
-    fun `insertAndGetNotice Test`() {
+    fun `insertNoticeAsOld and getOldNotice Test`() {
         // given
         val noticeMock = noticeMock()
         noticeDao.insertNoticeAsOld(noticeMock).blockingSubscribe()
 
         // when
-        val noticeFromDB = noticeDao.getNoticeRecord().blockingGet()[0]
+        val noticeFromDB = noticeDao.getOldNoticeList().blockingGet()[0]
 
         // then : 생성하고 insert 한 mock 와 불러온 데이터가 일치
         assertThat(noticeMock, `is`(noticeFromDB))
     }
 
     @Test
-    fun `updateNotice and getNoticeRecord Test`() {
+    fun `updateNoticeAsOld and getOldNoticeList Test`() {
         // given
         val noticeMock = noticeMock()
         noticeDao.insertNoticeAsOld(noticeMock).blockingSubscribe()
@@ -62,7 +62,7 @@ class NoticeDaoTest : LocalDbAbstract() {
         noticeDao.updateNotice(readNoticeMock).blockingSubscribe()
 
         // then : insert 후에 update 해도 데이터 수는 1개, 불러온 데이터가 mock 와 일치
-        val noticeFromDB = noticeDao.getNoticeRecord().blockingGet()
+        val noticeFromDB = noticeDao.getOldNoticeList().blockingGet()
         assertThat(noticeFromDB.size, `is`(1))
         assertThat(noticeFromDB[0].toString(), `is`(readNoticeMock.toString()))
     }

--- a/app/src/test/java/com/ku_stacks/ku_ring/persistence/PushDaoTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/persistence/PushDaoTest.kt
@@ -33,13 +33,13 @@ class PushDaoTest : LocalDbAbstract() {
     )
 
     @Test
-    fun `insertNotification and getNotification Test`() = runBlocking {
+    fun `insertNotification and getNotificationList Test`() = runBlocking {
         // given
         val pushMock = pushMock()
         pushDao.insertNotification(pushMock)
 
         // when
-        val pushFromDB = pushDao.getNotification().blockingFirst()[0]
+        val pushFromDB = pushDao.getNotificationList().blockingFirst()[0]
 
         // then
         /**
@@ -57,14 +57,14 @@ class PushDaoTest : LocalDbAbstract() {
     }
 
     @Test
-    fun `updateNotification As Old Test`() = runBlocking {
+    fun `update Notification As Old Test`() = runBlocking {
         // given
         val pushMock = pushMock()
         pushDao.insertNotification(pushMock)
         pushDao.updateNotificationAsOld(pushMock.articleId, false).blockingSubscribe()
 
         // when
-        val pushFromDB = pushDao.getNotification().blockingFirst()[0]
+        val pushFromDB = pushDao.getNotificationList().blockingFirst()[0]
 
         // then : updateConfirmedNotification 하면 isNew 값이 false
         assertThat(pushFromDB.articleId, `is`(pushMock.articleId))

--- a/app/src/test/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryTest.kt
@@ -28,13 +28,13 @@ class NoticeRepositoryTest {
     }
 
     @Test
-    fun `insertNotice Test`() {
+    fun `insert Notice As Old Test`() {
         // given
         val mockData = mockNoticeEntity()
-        Mockito.`when`(dao.insertNotice(mockData)).thenReturn(Completable.complete())
+        Mockito.`when`(dao.insertNoticeAsOld(mockData)).thenReturn(Completable.complete())
 
         // when + then
-        repository.insertNotice(mockData.articleId, mockData.category)
+        repository.insertNoticeAsOld(mockData.articleId, mockData.category)
             .test()
             .assertComplete()
     }

--- a/app/src/test/java/com/ku_stacks/ku_ring/repository/PushRepositoryTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/repository/PushRepositoryTest.kt
@@ -25,14 +25,14 @@ class PushRepositoryTest {
     }
 
     @Test
-    fun `get MyNotification Test`() {
+    fun `get MyNotification List Test`() {
         // given
         val mockData = listOf(mockPushEntity())
-        Mockito.`when`(dao.getNotification()).thenReturn(Flowable.just(mockData))
+        Mockito.`when`(dao.getNotificationList()).thenReturn(Flowable.just(mockData))
 
         val expectedData = mockData.toPushList()
         // when + then
-        repository.getMyNotification()
+        repository.getMyNotificationList()
             .test()
             .assertNoErrors()
             .assertValue(expectedData)

--- a/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/HomeViewModelTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/HomeViewModelTest.kt
@@ -30,21 +30,6 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `update Notice Tobe Read Test`() {
-        // given
-        val mockData = mockNotice()
-        Mockito.`when`(noticeRepository.updateNoticeToBeRead(mockData.articleId, mockData.category))
-            .thenReturn(Completable.complete())
-
-        // when
-        viewModel.updateNoticeTobeRead(mockData)
-
-        // then
-        Mockito.verify(noticeRepository, times(1))
-            .updateNoticeToBeRead(mockData.articleId, mockData.category)
-    }
-
-    @Test
     fun `insert Notice Test`() {
         // given
         val mockData = mockNotice()

--- a/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/HomeViewModelTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/HomeViewModelTest.kt
@@ -30,17 +30,17 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun `insert Notice Test`() {
+    fun `insert Notice As Old Test`() {
         // given
         val mockData = mockNotice()
-        Mockito.`when`(noticeRepository.insertNotice(mockData.articleId, mockData.category))
+        Mockito.`when`(noticeRepository.insertNoticeAsOld(mockData.articleId, mockData.category))
             .thenReturn(Completable.complete())
 
         // when
-        viewModel.insertNotice(mockData.articleId, mockData.category)
+        viewModel.insertNoticeAsOld(mockData.articleId, mockData.category)
 
         // then
         Mockito.verify(noticeRepository, times(1))
-            .insertNotice(mockData.articleId, mockData.category)
+            .insertNoticeAsOld(mockData.articleId, mockData.category)
     }
 }

--- a/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/NotificationViewModelTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/NotificationViewModelTest.kt
@@ -36,18 +36,18 @@ class NotificationViewModelTest {
     }
 
     @Test
-    fun `get MyNotification Test`() {
+    fun `get MyNotification List Test`() {
         // given
         val mockData = listOf(MockUtil.mockPushEntity()).toPushList()
-        Mockito.`when`(pushRepository.getMyNotification()).thenReturn(Flowable.just(mockData))
+        Mockito.`when`(pushRepository.getMyNotificationList()).thenReturn(Flowable.just(mockData))
 
         // when
-        viewModel.getMyNotification()
+        viewModel.getMyNotificationList()
         viewModel.pushUiModelList.getOrAwaitValue()
 
         // then
         val expected = mockData.toPushUiModelList()
-        verify(pushRepository, atLeastOnce()).getMyNotification()
+        verify(pushRepository, atLeastOnce()).getMyNotificationList()
         assertEquals(expected, viewModel.pushUiModelList.value)
     }
 

--- a/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/NotificationViewModelTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/NotificationViewModelTest.kt
@@ -24,7 +24,6 @@ class NotificationViewModelTest {
 
     private lateinit var viewModel: NotificationViewModel
     private val pushRepository: PushRepository = mock()
-    private val noticeRepository: NoticeRepository = mock()
     private val pref: PreferenceUtil = mock()
 
     @get:Rule
@@ -32,7 +31,7 @@ class NotificationViewModelTest {
 
     @Before
     fun setup() {
-        viewModel = NotificationViewModel(pushRepository, noticeRepository, pref)
+        viewModel = NotificationViewModel(pushRepository, pref)
     }
 
     @Test

--- a/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/NotificationViewModelTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/NotificationViewModelTest.kt
@@ -63,18 +63,4 @@ class NotificationViewModelTest {
         // then
         verify(pushRepository, times(1)).updateNotificationAsOld(mockData.articleId)
     }
-
-    @Test
-    fun `update Notice Tobe Read Test`() {
-        // given
-        val articleId = "ababab"
-        val category = "학사"
-        Mockito.`when`(noticeRepository.updateNoticeToBeRead(articleId, category)).thenReturn(Completable.complete())
-
-        // when
-        viewModel.updateNoticeTobeRead(articleId, category)
-
-        // then
-        verify(noticeRepository, times(1)).updateNoticeToBeRead(articleId, category)
-    }
 }


### PR DESCRIPTION
### 배경
  - 공지 읽음 처리(local db 업데이트)를 공지리스트 화면, 공지 검색 화면, 내알림 화면에서 Item 클릭 시에 했었다.
  - 푸시알림으로 공지 내부에 들어가는 기능을 추가하면서 이 상황에도 공지 읽음을 처리해야하는 상황을 마주침
  - 의문 : 앞으로 공지 관련한 모든 기능을 추가할 때마다 공지읽음 처리를 하는 것이 과연 좋은 방법일까? 
 
### 변경 사항
  - 공지리스트 화면, 공지 검색화면, 내알림 화면, 푸시알림 클릭 시 local db 변경을 하지 않고, 공지 웹뷰 화면의 로딩이 끝난 시점에 local db에 읽음 처리를 하도록 수정하였다.
  - Activity 간에 intent를 통해 데이터를 전달할 때 key 값을 하드코딩했던 부분을 companion object를 이용하여 -> 변경에 용이하고 디버깅을 쉽게 할 수 있도록 수정하였다.
### 추가 변경 사항 (네이밍 수정)
  - 예전에 작성했던 코드를 다시 보면서 어떤 기능이었는지 한번에 이해되지 않았던 네이밍은 좋은 네이밍이 아니라고 판단하여 더 직관적이고 통일성이 있도록 변경하였다.
    - NoticeDao에서
      - insertNotice() -> insertNoticeAsOld()
      - getNoticeRecord() -> getOldNoticeList()
      - getReadNoticeRecord() -> getReadNoticeList()
      - getCountForReadNotice() -> getCountOfReadNotice()
    - PushDao 에서
      - getNotification() -> getNotificationList()