### PR TITLE
[디자인 수정] 공지 웹뷰 화면에서 CollapsingToolbarLayout 제거, 줌 in/out 가능하도록 개선

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -27,6 +27,7 @@
         <entry key="..\:/Users/user/Desktop/androidWorkspace/KUStack/app/src/main/res/layout/activity_home.xml" value="0.25" />
         <entry key="..\:/Users/user/Desktop/androidWorkspace/KUStack/app/src/main/res/layout/activity_main.xml" value="0.11322463768115942" />
         <entry key="..\:/Users/user/Desktop/androidWorkspace/KUStack/app/src/main/res/layout/activity_noti_custom.xml" value="0.19895833333333332" />
+        <entry key="..\:/Users/user/Desktop/androidWorkspace/KUStack/app/src/main/res/layout/activity_notice.xml" value="0.3564102564102564" />
         <entry key="..\:/Users/user/Desktop/androidWorkspace/KUStack/app/src/main/res/layout/activity_notification.xml" value="0.25" />
         <entry key="..\:/Users/user/Desktop/androidWorkspace/KUStack/app/src/main/res/layout/activity_on_boarding.xml" value="0.33" />
         <entry key="..\:/Users/user/Desktop/androidWorkspace/KUStack/app/src/main/res/layout/activity_personal_data.xml" value="0.28125" />

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.webkit.*
+import android.widget.ImageButton
 import android.widget.ProgressBar
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -19,6 +20,7 @@ class NoticeActivity : AppCompatActivity() {
 
     private lateinit var webView: WebView
     private lateinit var progressBar: ProgressBar
+    private lateinit var backButton: ImageButton
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -27,12 +29,18 @@ class NoticeActivity : AppCompatActivity() {
 
         webView = findViewById(R.id.notice_webView)
         progressBar = findViewById(R.id.notice_progressbar)
+        backButton = findViewById(R.id.notice_back_bt)
 
         val url = intent.getStringExtra(NOTICE_URL)
         val articleId = intent.getStringExtra(NOTICE_ARTICLE_ID)
         val category = intent.getStringExtra(NOTICE_CATEGORY)
 
         Timber.e("notice url : $url")
+
+        backButton.setOnClickListener {
+            finish()
+            overridePendingTransition(R.anim.anim_slide_left_enter, R.anim.anim_slide_left_exit)
+        }
 
         webView.webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeActivity.kt
@@ -48,11 +48,12 @@ class NoticeActivity : AppCompatActivity() {
         }
 
         webView.settings.apply {
-            builtInZoomControls = false
+            builtInZoomControls = true
             domStorageEnabled = true
             javaScriptEnabled = true
             loadWithOverviewMode = true
-            setSupportZoom(false)
+            setSupportZoom(true)
+            displayZoomControls = false
         }
 
         // WebChromeClient

--- a/app/src/main/res/layout/activity_notice.xml
+++ b/app/src/main/res/layout/activity_notice.xml
@@ -1,69 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.notice_webview.NoticeActivity">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/notice_app_bar"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/notice_header_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:stateListAnimator="@animator/appbar_elevation">
+        android:layout_height="56dp"
+        android:elevation="8dp"
+        android:background="@color/kus_background"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <com.google.android.material.appbar.CollapsingToolbarLayout
-            android:id="@+id/collapsingToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="56dp"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed|enterAlways">
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:background="@null"
+            android:src="@drawable/ic_ku_ring_home"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:background="@color/kus_background">
-
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
-                    android:background="@null"
-                    android:src="@drawable/ic_ku_ring_home"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-        </com.google.android.material.appbar.CollapsingToolbarLayout>
-    </com.google.android.material.appbar.AppBarLayout>
-
-    <androidx.core.widget.NestedScrollView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/notice_header_layout">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <ProgressBar
+            android:id="@+id/notice_progressbar"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="wrap_content"
+            android:translationZ="2dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0" />
 
-            <ProgressBar
-                android:id="@+id/notice_progressbar"
-                style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:translationZ="2dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.0" />
-
-            <WebView
-                android:id="@+id/notice_webView"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:scrollbars="none"
-                android:layout_marginStart="4dp"
-                android:layout_marginEnd="4dp" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.core.widget.NestedScrollView>
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+        <WebView
+            android:id="@+id/notice_webView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="4dp"
+            android:overScrollMode="never"
+            android:scrollbars="none" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_notice.xml
+++ b/app/src/main/res/layout/activity_notice.xml
@@ -14,14 +14,27 @@
         android:background="@color/kus_background"
         app:layout_constraintTop_toTopOf="parent">
 
+        <ImageButton
+            android:id="@+id/notice_back_bt"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_marginStart="16dp"
+            android:background="@null"
+            android:padding="4dp"
+            android:src="@drawable/ic_back"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="@color/kus_primary" />
+
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
             android:background="@null"
             android:src="@drawable/ic_ku_ring_home"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_notice.xml
+++ b/app/src/main/res/layout/activity_notice.xml
@@ -28,6 +28,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:background="@color/white"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/notice_header_layout">
 


### PR DESCRIPTION
### 배경
  - 사용자가 웹뷰 스크롤을 내리면서 조금이라도 더 넓은 화면을 활용할 수 있도록 기존에는 CoordinatorLayout + CollapsingToobarLayout 을 상단바를 적용했었다.
  - 건국대학교의 홈페이지의 웹뷰(모바일용의 좁은 화면)에서는 공지 내에 너비가 넓은 이미지가 있는 경우 스크린 가로폭을 이미지에 맞추고 있었음
    - 그로 인해 넓은 이미지가 있는 경우 가로 스크롤이 생김
    - 이미지 없이 텍스트만 있는 공지에서는 문제가 되지 않음
  -  CoordinatorLayout + CollapsingToobarLayout 을 사용하면서 가로 스크롤이 있는 웹뷰를 보여줄때 가로스크롤이 잘 되지 않는 이슈가 있었다. (정확히 가로 방향 스크롤을 해야지만 스크롤이 되는 현상)
  - 다른 앱들을 참고해 봤을 때(에브리타임, 카카오톡) 웹뷰에서 CoordinatorLayout은 적용하는 경우는 찾지 못했음

### 변경 사항
 - 사용하던 CoordinatorLayout을 포기하고 일반 상단바로 적용
 - 웹뷰 내에서 zoom In/Out 가능하도록 변경
   - 이미지 너비가 넓은 경우에는 최대 이미지너비가 zoom out 할 수 있는 최대 너비가 된다.
 - 웹뷰 내에서 가로스크롤과 세로스크롤이 자연스럽게 적용 
 - 상단바에서 X 버튼 추가, 쿠링 아이콘 중앙으로 위치 이동