### PR TITLE
[수정] 공지 보관함 버그픽스

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ android {
                     appName : "@string/app_name_debug",
                     appIcon : "@drawable/ic_ku_ring_launcher_dev"
             ]
-            buildConfigField "String", "API_BASE_URL", "\"https://kuring-dev.herokuapp.com/api/v1/\""
+            buildConfigField "String", "API_BASE_URL", "\"http://ec2-43-207-30-148.ap-northeast-1.compute.amazonaws.com/api/v1/\""
             buildConfigField "String", "WEB_SOCKET_URL", "\"wss://kuring-dev.herokuapp.com/kuring/search\""
             buildConfigField "String", "KURING_CAMPUS_OPEN_CHANNEL_URL", "\"kuring_main_anonymous\""
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
@@ -42,17 +42,16 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
         if (isNoticeNotification(remoteMessage)) {
             val articleId = remoteMessage.data["articleId"]!!
-            val categoryEng = remoteMessage.data["category"]!!
+            val category = remoteMessage.data["category"]!!
             val postedDate = remoteMessage.data["postedDate"]!!
             val subject = remoteMessage.data["subject"]!!
             val baseUrl = remoteMessage.data["baseUrl"]!!
 
             // insert into db
-            val categoryKr = WordConverter.convertEnglishToKorean(categoryEng)
             val receivedDate = DateUtil.getCurrentTime()
             insertNotificationIntoDatabase(
                 articleId = articleId,
-                category = categoryKr,
+                category = category,
                 postedDate = postedDate,
                 subject = subject,
                 baseUrl = baseUrl,
@@ -60,13 +59,14 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
             )
 
             // show notification
-            val webUrl = UrlGenerator.generateNoticeUrl(articleId = articleId, category = categoryKr, baseUrl = baseUrl)
+            val webUrl = UrlGenerator.generateNoticeUrl(articleId = articleId, category = category, baseUrl = baseUrl)
+            val categoryKr = WordConverter.convertEnglishToKorean(category)
             showNotificationWithUrl(
                 title = subject,
                 body = categoryKr,
                 url = webUrl,
                 articleId = articleId,
-                category = categoryEng
+                category = category
             )
         } else if (isCustomNotification(remoteMessage)) {
             val type = remoteMessage.data["type"]!!

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/DataMapperUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/DataMapperUtil.kt
@@ -1,6 +1,13 @@
 package com.ku_stacks.ku_ring.data.mapper
 
+import timber.log.Timber
+
 fun splitSubjectAndTag(subject: String): Pair<String, List<String>> {
+    if (subject.isEmpty()) {
+        Timber.e("subject split failed (empty), so empty contents are returned.")
+        return Pair("", emptyList())
+    }
+
     val tagList = mutableListOf<String>()
     var startIdx = 0
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/EntityToModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/EntityToModelMapper.kt
@@ -4,6 +4,7 @@ import com.ku_stacks.ku_ring.data.db.NoticeEntity
 import com.ku_stacks.ku_ring.data.db.PushEntity
 import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.data.model.Push
+import timber.log.Timber
 
 fun List<PushEntity>.toPushList(): List<Push> {
     return map {
@@ -24,6 +25,10 @@ fun List<PushEntity>.toPushList(): List<Push> {
 fun List<NoticeEntity>.toNoticeList() = map { it.toNotice() }
 
 fun NoticeEntity.toNotice(): Notice {
+    if (this.subject.isEmpty()) {
+        Timber.e("Notice.subject is empty: $this")
+    }
+
     val (subject, tag) = splitSubjectAndTag(subject)
     return Notice(
         postedDate = postedDate,

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/EntityToModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/EntityToModelMapper.kt
@@ -4,15 +4,23 @@ import com.ku_stacks.ku_ring.data.db.NoticeEntity
 import com.ku_stacks.ku_ring.data.db.PushEntity
 import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.data.model.Push
+import com.ku_stacks.ku_ring.util.WordConverter
+import com.ku_stacks.ku_ring.util.isOnlyAlphabets
 import timber.log.Timber
 
 fun List<PushEntity>.toPushList(): List<Push> = map { it.toPush() }
 
 fun PushEntity.toPush(): Push {
     val subjectAndTag = splitSubjectAndTag(subject.trim())
+    // DO NOT ERASE: legacy version stores category to korean.
+    val categoryEng = if (category.isOnlyAlphabets()) {
+        category
+    } else {
+        WordConverter.convertKoreanToEnglish(category)
+    }
     return Push(
         articleId = articleId,
-        category = category,
+        category = categoryEng,
         postedDate = postedDate,
         subject = subjectAndTag.first,
         baseUrl = baseUrl,

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/EntityToModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/EntityToModelMapper.kt
@@ -6,20 +6,20 @@ import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.data.model.Push
 import timber.log.Timber
 
-fun List<PushEntity>.toPushList(): List<Push> {
-    return map {
-        val subjectAndTag = splitSubjectAndTag(it.subject.trim())
-        Push(
-            articleId = it.articleId,
-            category = it.category,
-            postedDate = it.postedDate,
-            subject = subjectAndTag.first,
-            baseUrl = it.baseUrl,
-            isNew = it.isNew,
-            receivedDate = it.receivedDate,
-            tag = subjectAndTag.second
-        )
-    }
+fun List<PushEntity>.toPushList(): List<Push> = map { it.toPush() }
+
+fun PushEntity.toPush(): Push {
+    val subjectAndTag = splitSubjectAndTag(subject.trim())
+    return Push(
+        articleId = articleId,
+        category = category,
+        postedDate = postedDate,
+        subject = subjectAndTag.first,
+        baseUrl = baseUrl,
+        isNew = isNew,
+        receivedDate = receivedDate,
+        tag = subjectAndTag.second
+    )
 }
 
 fun List<NoticeEntity>.toNoticeList() = map { it.toNotice() }

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ModelToUiModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/mapper/ModelToUiModelMapper.kt
@@ -4,6 +4,8 @@ import com.ku_stacks.ku_ring.data.model.Push
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushContentUiModel
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushDataUiModel
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushDateHeaderUiModel
+import com.ku_stacks.ku_ring.util.WordConverter
+import com.ku_stacks.ku_ring.util.isOnlyAlphabets
 
 fun List<Push>.toPushUiModelList(): List<PushDataUiModel> {
     val pushDataList = ArrayList<PushDataUiModel>()
@@ -25,9 +27,14 @@ fun List<Push>.toPushUiModelList(): List<PushDataUiModel> {
 }
 
 fun Push.toPushContentUiModel(): PushContentUiModel {
+    val categoryKor = if (category.isOnlyAlphabets()) {
+        WordConverter.convertEnglishToKorean(category)
+    } else {
+        category
+    }
     return PushContentUiModel(
         articleId = articleId,
-        category = category,
+        categoryKor = categoryKor,
         postedDate = postedDate,
         subject = subject,
         baseUrl = baseUrl,

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/ui_model/PushUiModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/ui_model/PushUiModel.kt
@@ -8,7 +8,7 @@ data class PushDateHeaderUiModel (
 
 data class PushContentUiModel (
     val articleId: String,
-    val category: String,
+    val categoryKor: String,
     val postedDate: String,
     val subject: String,
     val baseUrl: String,

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebActivity.kt
@@ -16,6 +16,7 @@ import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.databinding.ActivityNoticeWebBinding
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushContentUiModel
 import com.ku_stacks.ku_ring.util.UrlGenerator
+import com.ku_stacks.ku_ring.util.WordConverter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import timber.log.Timber
@@ -135,12 +136,13 @@ class NoticeWebActivity : AppCompatActivity() {
 
         fun createIntent(context: Context, pushContent: PushContentUiModel): Intent {
             with(pushContent) {
-                val url = UrlGenerator.generateNoticeUrl(articleId, category, baseUrl)
+                val categoryEng = WordConverter.convertKoreanToEnglish(categoryKor)
+                val url = UrlGenerator.generateNoticeUrl(articleId, categoryEng, baseUrl)
                 return createIntent(
                     context,
                     url,
                     articleId,
-                    category,
+                    categoryEng,
                     postedDate,
                     concatSubjectAndTag(subject, tag)
                 )

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/notice_webview/NoticeWebViewModel.kt
@@ -52,6 +52,7 @@ class NoticeWebViewModel @Inject constructor(
     }
 
     fun onSaveButtonClick() {
+        Timber.e("Save button click: $articleId, $category, $url, $postedDate, $subject")
         if (articleId == null || category == null || url == null || postedDate == null || subject == null) return
         viewModelScope.launch {
             noticeRepository.updateSavedStatus(articleId, category, !isSaved.value)

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/StringUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/StringUtil.kt
@@ -3,3 +3,5 @@ package com.ku_stacks.ku_ring.util
 import com.ku_stacks.ku_ring.BuildConfig
 
 infix fun String.or(that: String): String =  if (BuildConfig.DEBUG) this else that
+
+fun String.isOnlyAlphabets() = matches("[a-zA-Z]*$".toRegex())

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/UrlGenerator.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/UrlGenerator.kt
@@ -1,10 +1,16 @@
 package com.ku_stacks.ku_ring.util
 
+import timber.log.Timber
+
 object UrlGenerator {
 
     @JvmStatic
     fun generateNoticeUrl(articleId: String, category: String, baseUrl: String): String {
-        return if (category == "도서관") {
+        if (!category.isOnlyAlphabets()) {
+            Timber.e("Only english category should be given: $category")
+        }
+
+        return if (category == "library") {
             "$baseUrl/$articleId"
         } else {
             "$baseUrl?id=$articleId"

--- a/app/src/main/res/layout/item_notification.xml
+++ b/app/src/main/res/layout/item_notification.xml
@@ -57,7 +57,7 @@
                 android:layout_marginStart="40dp"
                 android:layout_marginTop="2dp"
                 android:fontFamily="@font/sfpro_display_regular"
-                android:text="@{pushContentUiModel.category}"
+                android:text="@{pushContentUiModel.categoryKor}"
                 android:textColor="@color/kus_gray"
                 android:textSize="12sp"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/test/java/com/ku_stacks/ku_ring/util/StringUtilTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/util/StringUtilTest.kt
@@ -1,0 +1,47 @@
+package com.ku_stacks.ku_ring.util
+
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class StringUtilTest {
+
+    @Test
+    fun `isOnlyAlphabets - empty string`() {
+        isOnlyAlphabetsTest("", true)
+    }
+
+    @Test
+    fun `isOnlyAlphabets - only alphabets`() {
+        isOnlyAlphabetsTest("alphabet", true)
+    }
+
+    @Test
+    fun `isOnlyAlphabets - only numbers`() {
+        isOnlyAlphabetsTest("123456", false)
+    }
+
+    @Test
+    fun `isOnlyAlphabets - alphabets and numbers`() {
+        isOnlyAlphabetsTest("abc123", false)
+    }
+
+    @Test
+    fun `isOnlyAlphabets - korean letters`() {
+        isOnlyAlphabetsTest("가힣", false)
+    }
+
+    @Test
+    fun `isOnlyAlphabets - special characters`() {
+        isOnlyAlphabetsTest("???", false)
+    }
+
+    private fun isOnlyAlphabetsTest(string: String, expected: Boolean) {
+        // given, when
+        val actual = string.isOnlyAlphabets()
+        // then
+        assertThat(actual, `is`(expected))
+    }
+
+
+}


### PR DESCRIPTION
# 수정사항

## Dev 서버 URL 수정
현재 검색 소켓이 작동하지 않아 API URL만 수정했습니다. 

## `splitSubjectAndTag()`
[Crashlytics 로그](https://console.firebase.google.com/u/0/project/ku-stack/crashlytics/app/android:com.ku_stacks.ku_ring/issues/28f84fa34f25ceef2bef18def2e567d5?time=last-ninety-days&versions=1.2.8%20(20)&sessionEventKey=64004DF401DD00010DBE21DE08CF40B5_1784296132468777733)를 분석한 결과 **보관함에 보관된 공지 중 `subject`가 빈 문자열인 `NoticeEntity`가 있다**는 결과를 얻었는데, 일반적인 흐름상 나올 수 없는 결과라 의문입니다. 

일단 앱이 강제 종료되지는 않게 하기 위해 `splitSubjectAndTag` 함수에 빈 문자열이 주어졌을 때  `NoSuchElementException` 대신 빈 문자열과 리스트 `Pair`를 반환하도록 수정했습니다.

이 문제는 계속 지켜볼 예정입니다.

## 알림 화면에서 WebView로 들어갔을 때 공지를 저장할 수 없던 문제 해결
> 원인: `PushEntity`에 `category`가 한글로 저장되기 때문이었습니다. (`bachleor` 대신 `학사`로 저장됨)

`PushEntity`와 `Push`에는 무조건 영어로 저장되게 수정했고, `PushContentUiModel`에는 사용자에게 보여주기 위해 한글로 변환하여 넘겨줍니다. `PushContentUiModel`의 `category` 변수의 이름도 한글임을 강조하기 위해 `categoryKor`로 변경했습니다. 

카테고리 변수는 특별한 경우가 아니라면 영어로 사용한다는 컨벤션을 정해도 좋을 것 같습니다. Unit test에서 `PushEntity`가 mock될 때도 category가 영어로 주어지고 있습니다.

```Kotlin
fun mockPushEntity() = PushEntity(
    articleId = "5b4a11b",
    category = "bachelor",
    ...
)
```

카테고리를 참조하는 다른 함수에서도 영어 카테고리만을 받는다고 전제하여 코드를 수정했습니다. 