### PR TITLE
[수정] 모든 코드를 다시 포매팅함

### DIFF
--- a/app/src/androidTest/java/com/ku_stacks/ku_ring/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/ku_stacks/ku_ring/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package com.ku_stacks.ku_ring
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
@@ -59,7 +59,11 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
             )
 
             // show notification
-            val webUrl = UrlGenerator.generateNoticeUrl(articleId = articleId, category = category, baseUrl = baseUrl)
+            val webUrl = UrlGenerator.generateNoticeUrl(
+                articleId = articleId,
+                category = category,
+                baseUrl = baseUrl
+            )
             val categoryKr = WordConverter.convertEnglishToKorean(category)
             showNotificationWithUrl(
                 title = subject,
@@ -128,7 +132,13 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
         }
     }
 
-    private fun showNotificationWithUrl(title: String?, body: String?, url: String?, articleId: String?, category: String?){
+    private fun showNotificationWithUrl(
+        title: String?,
+        body: String?,
+        url: String?,
+        articleId: String?,
+        category: String?
+    ) {
         val intent = NoticeWebActivity.createIntent(
             this,
             url,
@@ -154,7 +164,8 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)
 
-        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
@@ -186,7 +197,8 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)
 
-        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(

--- a/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/MyFireBaseMessagingService.kt
@@ -91,7 +91,7 @@ class MyFireBaseMessagingService : FirebaseMessagingService() {
         val baseUrl = remoteMessage.data["baseUrl"]
 
         return articleId != null && categoryEng != null && postedDate != null
-                && subject != null && baseUrl != null
+            && subject != null && baseUrl != null
     }
 
     private fun isCustomNotification(remoteMessage: RemoteMessage): Boolean {

--- a/app/src/main/java/com/ku_stacks/ku_ring/analytics/EventAnalytics.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/analytics/EventAnalytics.kt
@@ -11,8 +11,8 @@ class EventAnalytics(@ApplicationContext context: Context) {
         FirebaseAnalytics.getInstance(context)
     }
 
-    private fun logEvent(name: String, params: Bundle.() -> Unit){
-        delegate.logEvent(name, Bundle().apply{ params() })
+    private fun logEvent(name: String, params: Bundle.() -> Unit) {
+        delegate.logEvent(name, Bundle().apply { params() })
     }
 
     fun click(screenName: String, screenClass: String) {

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackClient.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackClient.kt
@@ -1,13 +1,13 @@
 package com.ku_stacks.ku_ring.data.api
 
-import com.ku_stacks.ku_ring.data.api.response.DefaultResponse
 import com.ku_stacks.ku_ring.data.api.request.FeedbackRequest
+import com.ku_stacks.ku_ring.data.api.response.DefaultResponse
 import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
 
 class FeedbackClient @Inject constructor(
     private val feedbackService: FeedbackService
-){
+) {
     fun sendFeedback(
         feedbackRequest: FeedbackRequest
     ): Single<DefaultResponse> = feedbackService.sendFeedback(feedbackRequest)

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/FeedbackService.kt
@@ -1,7 +1,7 @@
 package com.ku_stacks.ku_ring.data.api
 
-import com.ku_stacks.ku_ring.data.api.response.DefaultResponse
 import com.ku_stacks.ku_ring.data.api.request.FeedbackRequest
+import com.ku_stacks.ku_ring.data.api.response.DefaultResponse
 import io.reactivex.rxjava3.core.Single
 import retrofit2.http.Body
 import retrofit2.http.POST

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/NoticeClient.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/NoticeClient.kt
@@ -1,9 +1,9 @@
 package com.ku_stacks.ku_ring.data.api
 
+import com.ku_stacks.ku_ring.data.api.request.SubscribeRequest
 import com.ku_stacks.ku_ring.data.api.response.DefaultResponse
 import com.ku_stacks.ku_ring.data.api.response.NoticeListResponse
 import com.ku_stacks.ku_ring.data.api.response.SubscribeListResponse
-import com.ku_stacks.ku_ring.data.api.request.SubscribeRequest
 import io.reactivex.rxjava3.core.Single
 import javax.inject.Inject
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/NoticeService.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/NoticeService.kt
@@ -1,9 +1,9 @@
 package com.ku_stacks.ku_ring.data.api
 
+import com.ku_stacks.ku_ring.data.api.request.SubscribeRequest
 import com.ku_stacks.ku_ring.data.api.response.DefaultResponse
 import com.ku_stacks.ku_ring.data.api.response.NoticeListResponse
 import com.ku_stacks.ku_ring.data.api.response.SubscribeListResponse
-import com.ku_stacks.ku_ring.data.api.request.SubscribeRequest
 import io.reactivex.rxjava3.core.Single
 import retrofit2.http.Body
 import retrofit2.http.GET

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/api/response/NoticeListResponse.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/api/response/NoticeListResponse.kt
@@ -2,7 +2,7 @@ package com.ku_stacks.ku_ring.data.api.response
 
 import com.google.gson.annotations.SerializedName
 
-data class NoticeListResponse (
+data class NoticeListResponse(
     @SerializedName(value = "isSuccess")
     val isSuccess: Boolean,
     @SerializedName(value = "resultMsg")

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/source/NoticePagingSource.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/source/NoticePagingSource.kt
@@ -3,8 +3,8 @@ package com.ku_stacks.ku_ring.data.source
 import androidx.paging.PagingState
 import androidx.paging.rxjava3.RxPagingSource
 import com.ku_stacks.ku_ring.data.api.NoticeClient
-import com.ku_stacks.ku_ring.data.model.Notice
 import com.ku_stacks.ku_ring.data.mapper.toNoticeList
+import com.ku_stacks.ku_ring.data.model.Notice
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.schedulers.Schedulers
 import timber.log.Timber

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/websocket/SearchClient.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/websocket/SearchClient.kt
@@ -11,7 +11,6 @@ import io.reactivex.rxjava3.subjects.PublishSubject
 import org.java_websocket.client.WebSocketClient
 import org.java_websocket.handshake.ServerHandshake
 import timber.log.Timber
-import java.lang.Exception
 import java.net.URI
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.net.ssl.SSLSocketFactory
@@ -62,7 +61,7 @@ class SearchClient {
             override fun onOpen(handshakedata: ServerHandshake?) {
                 Timber.e("WebSocket onOpen")
                 preparingFlag.set(false)
-                if(lastKeyword.isNotEmpty()) {
+                if (lastKeyword.isNotEmpty()) {
                     searchStaff(lastKeyword)
                     searchNotice(lastKeyword)
                 }
@@ -75,10 +74,20 @@ class SearchClient {
                 val response = gson.fromJson(message, DefaultSearchResponse::class.java)
                 when (response.type) {
                     noticeType -> {
-                        publishNotice.onNext(gson.fromJson(message, SearchNoticeListResponse::class.java))
+                        publishNotice.onNext(
+                            gson.fromJson(
+                                message,
+                                SearchNoticeListResponse::class.java
+                            )
+                        )
                     }
                     staffType -> {
-                        publishStaff.onNext(gson.fromJson(message, SearchStaffListResponse::class.java))
+                        publishStaff.onNext(
+                            gson.fromJson(
+                                message,
+                                SearchStaffListResponse::class.java
+                            )
+                        )
                     }
                     heartbeatType -> {
                         Timber.e("received PONG")

--- a/app/src/main/java/com/ku_stacks/ku_ring/data/websocket/response/SearchStaffResponse.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/data/websocket/response/SearchStaffResponse.kt
@@ -1,7 +1,6 @@
 package com.ku_stacks.ku_ring.data.websocket.response
 
 import com.google.gson.annotations.SerializedName
-import java.io.Serializable
 
 data class SearchStaffResponse(
     @SerializedName(value = "name")

--- a/app/src/main/java/com/ku_stacks/ku_ring/di/DBModule.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/di/DBModule.kt
@@ -46,17 +46,14 @@ object DBModule {
 
     @Singleton
     @Provides
-    fun provideNoticeDao(database: KuRingDatabase): NoticeDao
-        = database.noticeDao()
+    fun provideNoticeDao(database: KuRingDatabase): NoticeDao = database.noticeDao()
 
     @Singleton
     @Provides
-    fun providePushDao(database: KuRingDatabase): PushDao
-        = database.pushDao()
+    fun providePushDao(database: KuRingDatabase): PushDao = database.pushDao()
 
     @Singleton
     @Provides
-    fun provideBlackUserDao(database: KuRingDatabase): BlackUserDao
-        = database.blackUserDao()
+    fun provideBlackUserDao(database: KuRingDatabase): BlackUserDao = database.blackUserDao()
 
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/initializer/AdMobInitializer.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/initializer/AdMobInitializer.kt
@@ -5,7 +5,7 @@ import androidx.startup.Initializer
 import com.google.android.gms.ads.MobileAds
 import timber.log.Timber
 
-class AdMobInitializer: Initializer<Unit> {
+class AdMobInitializer : Initializer<Unit> {
 
     override fun create(context: Context) {
         MobileAds.initialize(context) { initializerStatus ->

--- a/app/src/main/java/com/ku_stacks/ku_ring/initializer/AppsFlyerInitializer.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/initializer/AppsFlyerInitializer.kt
@@ -7,7 +7,7 @@ import com.appsflyer.attribution.AppsFlyerRequestListener
 import com.ku_stacks.ku_ring.BuildConfig
 import timber.log.Timber
 
-class AppsFlyerInitializer: Initializer<Unit> {
+class AppsFlyerInitializer : Initializer<Unit> {
 
     private val devKey = BuildConfig.APPS_FLYER_DEV_KEY
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryImpl.kt
@@ -43,15 +43,15 @@ class NoticeRepositoryImpl @Inject constructor(
             .cachedIn(scope)
 
         /**
-         하나의 insert에 대해서 2개 또는 3개의 변화 감지가 발생할 것임.
-         그 이유는 양옆 fragment 의 viewModel 에서 호출하기 때문
-        */
+        하나의 insert에 대해서 2개 또는 3개의 변화 감지가 발생할 것임.
+        그 이유는 양옆 fragment 의 viewModel 에서 호출하기 때문
+         */
         val flowableLocal = noticeDao.getReadNoticeList(true)
             .distinctUntilChanged { old, new ->
                 /**
-                 DB insert 되는 경우, 업데이트를 감지하기 위함이므로 성능을 위해
-                 모든 내용을 비교하기 보다는 size 만 비교하는 것으로 재정의함.
-                */
+                DB insert 되는 경우, 업데이트를 감지하기 위함이므로 성능을 위해
+                모든 내용을 비교하기 보다는 size 만 비교하는 것으로 재정의함.
+                 */
                 old.size == new.size
             }
 
@@ -110,18 +110,19 @@ class NoticeRepositoryImpl @Inject constructor(
             .subscribeOn(Schedulers.io())
             .toFlowable()
             .doOnNext { // local 데이터가 처음 발행될때 HashMap 에 저장 (단 한번만 실행)
-                if(isNewRecordHashMap.size == 0){
-                    for(localNotice in it){
+                if (isNewRecordHashMap.size == 0) {
+                    for (localNotice in it) {
                         isNewRecordHashMap[localNotice.articleId] = localNotice
                     }
                 }
             }
     }
 
-    private fun getFlowableRemoteNotice(type: String): Flowable<PagingData<Notice>>{
-         return Pager(
+    private fun getFlowableRemoteNotice(type: String): Flowable<PagingData<Notice>> {
+        return Pager(
             config = PagingConfig(
-                pageSize = 20,  /** 이것보다 PagingSource 에서 ItemCount 가 중요함 */
+                pageSize = 20,
+                /** 이것보다 PagingSource 에서 ItemCount 가 중요함 */
                 enablePlaceholders = true
             ),
             pagingSourceFactory = { NoticePagingSource(type, noticeClient) }
@@ -170,7 +171,7 @@ class NoticeRepositoryImpl @Inject constructor(
     override fun deleteAllNoticeRecord() { // for testing
         noticeDao.deleteAllNoticeRecord()
             .subscribeOn(Schedulers.io())
-            .subscribe ({
+            .subscribe({
                 Timber.e("delete Notice db success")
             }, {
                 Timber.e("delete Notice db fail")

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/PushRepositoryImpl.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/PushRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.ku_stacks.ku_ring.repository
 
 import com.ku_stacks.ku_ring.data.db.PushDao
-import com.ku_stacks.ku_ring.data.model.Push
 import com.ku_stacks.ku_ring.data.mapper.toPushList
+import com.ku_stacks.ku_ring.data.model.Push
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.schedulers.Schedulers
@@ -35,6 +35,6 @@ class PushRepositoryImpl @Inject constructor(
     override fun deleteAllNotification() {
         dao.deleteAllNotification()
             .subscribeOn(Schedulers.io())
-            .subscribe({},{})
+            .subscribe({}, {})
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/repository/SubscribeRepository.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/repository/SubscribeRepository.kt
@@ -1,7 +1,6 @@
 package com.ku_stacks.ku_ring.repository
 
 import com.ku_stacks.ku_ring.data.api.request.SubscribeRequest
-import com.ku_stacks.ku_ring.data.api.response.DefaultResponse
 import io.reactivex.rxjava3.core.Single
 
 interface SubscribeRepository {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatActivity.kt
@@ -58,13 +58,21 @@ class ChatActivity : AppCompatActivity() {
             viewModel.sendMessage(message)
         }
         binding.chatMessageEt.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) =
+                Unit
+
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
             override fun afterTextChanged(s: Editable?) {
                 if (s.isNullOrEmpty()) { // modify tint color
-                    ImageViewCompat.setImageTintList(binding.chatSendBt, ColorStateList.valueOf(getColor(R.color.kus_green_50)))
+                    ImageViewCompat.setImageTintList(
+                        binding.chatSendBt,
+                        ColorStateList.valueOf(getColor(R.color.kus_green_50))
+                    )
                 } else {
-                    ImageViewCompat.setImageTintList(binding.chatSendBt, ColorStateList.valueOf(getColor(R.color.kus_green)))
+                    ImageViewCompat.setImageTintList(
+                        binding.chatSendBt,
+                        ColorStateList.valueOf(getColor(R.color.kus_green))
+                    )
                 }
 
                 s?.length?.let { len ->
@@ -81,8 +89,12 @@ class ChatActivity : AppCompatActivity() {
 
     private fun setupRecyclerView() {
         chatMessageAdapter = ChatMessageAdapter(
-            onErrorClick = { sentMessageUiModel ->  makeResendDialog(sentMessageUiModel) },
-            onMessageLongClick = { receivedMessageUiModel ->  makeChatActionDialog(receivedMessageUiModel) }
+            onErrorClick = { sentMessageUiModel -> makeResendDialog(sentMessageUiModel) },
+            onMessageLongClick = { receivedMessageUiModel ->
+                makeChatActionDialog(
+                    receivedMessageUiModel
+                )
+            }
         )
 
         binding.chatRecyclerview.apply {
@@ -125,7 +137,7 @@ class ChatActivity : AppCompatActivity() {
         }
     }
 
-    private fun makeResendDialog(sentMessageUiModel : SentMessageUiModel) {
+    private fun makeResendDialog(sentMessageUiModel: SentMessageUiModel) {
         makeDialog(
             description = getString(R.string.chat_resend_message),
             leftText = getString(R.string.chat_delete),

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatMessageAdapter.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatMessageAdapter.kt
@@ -117,14 +117,14 @@ class ChatMessageAdapter(
         override fun areContentsTheSame(oldItem: ChatUiModel, newItem: ChatUiModel): Boolean {
             return if (oldItem is ReceivedMessageUiModel && newItem is ReceivedMessageUiModel) {
                 oldItem.messageId == newItem.messageId
-                        && oldItem.message == newItem.message
+                    && oldItem.message == newItem.message
             } else if (oldItem is SentMessageUiModel && newItem is SentMessageUiModel) {
                 oldItem.messageId == newItem.messageId
-                        && oldItem.message == newItem.message
-                        && oldItem.isPending == newItem.isPending
+                    && oldItem.message == newItem.message
+                    && oldItem.isPending == newItem.isPending
             } else if (oldItem is AdminMessageUiModel && newItem is AdminMessageUiModel) {
                 oldItem.messageId == newItem.messageId
-                        && oldItem.message == newItem.message
+                    && oldItem.message == newItem.message
             } else {
                 false
             }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatMessageAdapter.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatMessageAdapter.kt
@@ -9,10 +9,15 @@ import com.ku_stacks.ku_ring.R
 import com.ku_stacks.ku_ring.databinding.ItemChatAdminBinding
 import com.ku_stacks.ku_ring.databinding.ItemChatReceiveBinding
 import com.ku_stacks.ku_ring.databinding.ItemChatSendBinding
-import com.ku_stacks.ku_ring.ui.chat.ui_model.*
-import com.ku_stacks.ku_ring.ui.chat.viewholder.*
+import com.ku_stacks.ku_ring.ui.chat.ui_model.AdminMessageUiModel
+import com.ku_stacks.ku_ring.ui.chat.ui_model.ChatUiModel
+import com.ku_stacks.ku_ring.ui.chat.ui_model.ReceivedMessageUiModel
+import com.ku_stacks.ku_ring.ui.chat.ui_model.SentMessageUiModel
+import com.ku_stacks.ku_ring.ui.chat.viewholder.AdminViewHolder
+import com.ku_stacks.ku_ring.ui.chat.viewholder.ReceiveViewHolder
+import com.ku_stacks.ku_ring.ui.chat.viewholder.SealedChatViewHolder
+import com.ku_stacks.ku_ring.ui.chat.viewholder.SendViewHolder
 import com.ku_stacks.ku_ring.util.DateUtil.areSameDate
-import timber.log.Timber
 
 class ChatMessageAdapter(
     private val onErrorClick: (SentMessageUiModel) -> Unit,
@@ -21,7 +26,8 @@ class ChatMessageAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SealedChatViewHolder {
         return when (viewType) {
             CHAT_RECEIVED -> {
-                val view = LayoutInflater.from(parent.context).inflate(R.layout.item_chat_receive, parent, false)
+                val view = LayoutInflater.from(parent.context)
+                    .inflate(R.layout.item_chat_receive, parent, false)
                 val binding = ItemChatReceiveBinding.bind(view)
                 ReceiveViewHolder(binding).apply {
                     binding.chatMessageLayout.setOnLongClickListener {
@@ -33,7 +39,8 @@ class ChatMessageAdapter(
                 }
             }
             CHAT_SENT -> {
-                val view = LayoutInflater.from(parent.context).inflate(R.layout.item_chat_send, parent, false)
+                val view = LayoutInflater.from(parent.context)
+                    .inflate(R.layout.item_chat_send, parent, false)
                 val binding = ItemChatSendBinding.bind(view)
                 SendViewHolder(binding).apply {
                     binding.chatSendErrorIv.setOnClickListener {
@@ -44,7 +51,8 @@ class ChatMessageAdapter(
                 }
             }
             CHAT_ADMIN -> {
-                val view = LayoutInflater.from(parent.context).inflate(R.layout.item_chat_admin, parent, false)
+                val view = LayoutInflater.from(parent.context)
+                    .inflate(R.layout.item_chat_admin, parent, false)
                 val binding = ItemChatAdminBinding.bind(view)
                 AdminViewHolder(binding)
             }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatRecyclerDataObserver.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ChatRecyclerDataObserver.kt
@@ -2,7 +2,6 @@ package com.ku_stacks.ku_ring.ui.chat
 
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import java.lang.IllegalStateException
 
 // Reference : https://github.com/sendbird/sendbird-chat-sample-android/blob/main/commonmodule/src/main/java/com/sendbird/chat/module/utils/ChatRecyclerDataObserver.kt
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ui_model/ChatUiModelMapper.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/chat/ui_model/ChatUiModelMapper.kt
@@ -14,11 +14,10 @@ fun List<BaseMessage>.toChatUiModelList(blackUserList: List<String>): List<ChatU
         Timber.e("currentUser is null!")
     }
 
-    for(message in this) {
+    for (message in this) {
         if (message is AdminMessage) {
             chatUiModelList.add(message.toAdminMessageUiModel())
-        }
-        else if (message is UserMessage) {
+        } else if (message is UserMessage) {
             if (message.sender?.userId == currentUser?.userId) {
                 chatUiModelList.add(message.toSentMessageUiModel(isPending = false))
             } else {
@@ -26,8 +25,7 @@ fun List<BaseMessage>.toChatUiModelList(blackUserList: List<String>): List<ChatU
                     chatUiModelList.add(message.toReceivedMessageUiModel())
                 }
             }
-        }
-        else {
+        } else {
             Timber.e("message type is strange! ${message.messageId}")
         }
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionActivity.kt
@@ -36,7 +36,7 @@ class EditSubscriptionActivity : AppCompatActivity() {
         binding.viewModel = viewModel
 
         binding.dismissBt.setOnClickListener {
-            if(viewModel.hasUpdate.value == true) {
+            if (viewModel.hasUpdate.value == true) {
                 viewModel.saveSubscribe()
             }
             finish()
@@ -57,7 +57,7 @@ class EditSubscriptionActivity : AppCompatActivity() {
 
     private fun setupView() {
         viewModel.firstRunFlag = intent.getBooleanExtra(FIRST_RUN_FLAG, false)
-        if(viewModel.firstRunFlag) {
+        if (viewModel.firstRunFlag) {
             binding.dismissBt.visibility = View.GONE
             binding.rollbackBt.visibility = View.GONE
             binding.startBt.visibility = View.VISIBLE
@@ -80,18 +80,22 @@ class EditSubscriptionActivity : AppCompatActivity() {
         }
 
         binding.subscribeRecyclerview.apply {
-            layoutManager = GridLayoutManager(this@EditSubscriptionActivity,
+            layoutManager = GridLayoutManager(
+                this@EditSubscriptionActivity,
                 3,
                 GridLayoutManager.VERTICAL,
-                false)
+                false
+            )
             adapter = subscribeAdapter
         }
 
         binding.unsubscribeRecyclerview.apply {
-            layoutManager = GridLayoutManager(this@EditSubscriptionActivity,
+            layoutManager = GridLayoutManager(
+                this@EditSubscriptionActivity,
                 3,
                 GridLayoutManager.VERTICAL,
-                false)
+                false
+            )
             adapter = unSubscribeListAdapter
         }
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/EditSubscriptionViewModel.kt
@@ -13,8 +13,6 @@ import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import timber.log.Timber
 import javax.inject.Inject
-import java.util.*
-import kotlin.Comparator
 
 @HiltViewModel
 class EditSubscriptionViewModel @Inject constructor(
@@ -52,11 +50,10 @@ class EditSubscriptionViewModel @Inject constructor(
 
     init {
         firebaseMessaging.token.addOnCompleteListener { task ->
-            if(!task.isSuccessful) {
+            if (!task.isSuccessful) {
                 Timber.e("Firebase instanceId fail : ${task.exception}")
                 analytics.errorEvent("${task.exception}", className)
-            }
-            else if (task.result == null) {
+            } else if (task.result == null) {
                 Timber.e("Fcm Token is null")
                 analytics.errorEvent("Fcm Token is null!", className)
             } else {
@@ -70,9 +67,11 @@ class EditSubscriptionViewModel @Inject constructor(
         fcmToken?.let {
             _subscriptionList.clear()
             _unSubscriptionList.clear()
-            _unSubscriptionList.addAll(listOf(
-                "학사", "장학", "취창업", "국제", "학생", "산학", "일반", "도서관"
-            ))
+            _unSubscriptionList.addAll(
+                listOf(
+                    "학사", "장학", "취창업", "국제", "학생", "산학", "일반", "도서관"
+                )
+            )
 
             disposable.add(
                 repository.fetchSubscriptionFromRemote(fcmToken!!)
@@ -88,7 +87,7 @@ class EditSubscriptionViewModel @Inject constructor(
     }
 
     fun saveSubscribe() {
-        if(initFlag == false) {
+        if (initFlag == false) {
             return
         }
 
@@ -127,7 +126,7 @@ class EditSubscriptionViewModel @Inject constructor(
     }
 
     fun refreshAfterUpdate() {
-        if(firstRunFlag) {
+        if (firstRunFlag) {
             return
         }
         val localSubscription = repository.getSubscriptionFromLocal()
@@ -145,7 +144,7 @@ class EditSubscriptionViewModel @Inject constructor(
     }
 
     private fun initialSortSubscription(subscribingList: List<String>) {
-        for(str in subscribingList){
+        for (str in subscribingList) {
             _subscriptionList.add(str)
             _unSubscriptionList.remove(str)
         }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/adapter/SubscribeAdapter.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/adapter/SubscribeAdapter.kt
@@ -14,7 +14,8 @@ class SubscribeAdapter(
     SubscriptionDiffCallback
 ) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SubscribeViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_subscription, parent, false)
+        val view =
+            LayoutInflater.from(parent.context).inflate(R.layout.item_subscription, parent, false)
         val binding = ItemSubscriptionBinding.bind(view)
         return SubscribeViewHolder(binding, itemClick)
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/adapter/UnSubscribeAdapter.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/adapter/UnSubscribeAdapter.kt
@@ -14,7 +14,8 @@ class UnSubscribeAdapter(
     UnSubscriptionDiffCallback
 ) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UnSubscribeViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_unsubscription, parent, false)
+        val view =
+            LayoutInflater.from(parent.context).inflate(R.layout.item_unsubscription, parent, false)
         val binding = ItemUnsubscriptionBinding.bind(view)
         return UnSubscribeViewHolder(binding, itemClick)
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/viewholder/SubscribeViewHolder.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/edit_subscription/viewholder/SubscribeViewHolder.kt
@@ -6,7 +6,7 @@ import com.ku_stacks.ku_ring.databinding.ItemSubscriptionBinding
 class SubscribeViewHolder(
     private val binding: ItemSubscriptionBinding,
     private val itemClick: (String) -> Unit,
-    ) : RecyclerView.ViewHolder(binding.root) {
+) : RecyclerView.ViewHolder(binding.root) {
 
     fun bind(category: String) {
         binding.category = category

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/MainActivity.kt
@@ -16,7 +16,7 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
 
-    private val pageChangeCallback = object: ViewPager2.OnPageChangeCallback() {
+    private val pageChangeCallback = object : ViewPager2.OnPageChangeCallback() {
         override fun onPageSelected(position: Int) {
             binding.mainBottomNavigation.selectedItemId = when (position) {
                 0 -> R.id.notice_screen

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/campus_onboarding/CampusFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/campus_onboarding/CampusFragment.kt
@@ -116,13 +116,27 @@ class CampusFragment : Fragment() {
                 binding.campusSetNicknameLayout.root.visibility = View.VISIBLE
                 binding.campusAutoLoginLayout.root.visibility = View.GONE
 
-                binding.campusSetNicknameLayout.nicknameEt.addTextChangedListener(object : TextWatcher {
-                    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
-                    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
+                binding.campusSetNicknameLayout.nicknameEt.addTextChangedListener(object :
+                    TextWatcher {
+                    override fun beforeTextChanged(
+                        s: CharSequence?,
+                        start: Int,
+                        count: Int,
+                        after: Int
+                    ) = Unit
+
+                    override fun onTextChanged(
+                        s: CharSequence?,
+                        start: Int,
+                        before: Int,
+                        count: Int
+                    ) = Unit
+
                     override fun afterTextChanged(s: Editable?) {
                         val isValidFormat = viewModel.isValidNicknameFormat(s.toString())
                         if (isValidFormat) {
-                            binding.campusSetNicknameLayout.nicknameFormatDescTv.text = getString(R.string.nickname_valid_format)
+                            binding.campusSetNicknameLayout.nicknameFormatDescTv.text =
+                                getString(R.string.nickname_valid_format)
                             binding.campusSetNicknameLayout.nicknameFormatDescTv.setTextColor(
                                 ContextCompat.getColor(
                                     requireContext(),
@@ -130,7 +144,8 @@ class CampusFragment : Fragment() {
                                 )
                             )
                         } else {
-                            binding.campusSetNicknameLayout.nicknameFormatDescTv.text = getString(R.string.nickname_not_valid_format)
+                            binding.campusSetNicknameLayout.nicknameFormatDescTv.text =
+                                getString(R.string.nickname_not_valid_format)
                             binding.campusSetNicknameLayout.nicknameFormatDescTv.setTextColor(
                                 ContextCompat.getColor(
                                     requireContext(),
@@ -172,7 +187,10 @@ class CampusFragment : Fragment() {
 
         val intent = Intent(requireActivity(), ChatActivity::class.java)
         startActivity(intent)
-        requireActivity().overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+        requireActivity().overridePendingTransition(
+            R.anim.anim_slide_right_enter,
+            R.anim.anim_stay_exit
+        )
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/campus_onboarding/CampusState.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/campus_onboarding/CampusState.kt
@@ -1,6 +1,6 @@
 package com.ku_stacks.ku_ring.ui.main.campus_onboarding
 
-enum class CampusState{
+enum class CampusState {
     LOGIN_STATE,
     SET_NICKNAME_STATE,
     AUTO_LOGIN_STATE

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/NoticeFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/NoticeFragment.kt
@@ -52,11 +52,15 @@ class NoticeFragment : Fragment() {
         getFcmToken()
     }
 
-    private fun setupHeader(){
+    private fun setupHeader() {
         val pagerAdapter = CategoryPagerAdapter(childFragmentManager, lifecycle)
         binding.homeViewpager.adapter = pagerAdapter
 
-        TabLayoutMediator(binding.mainHeader.tabLayout, binding.homeViewpager,true) { tab, position ->
+        TabLayoutMediator(
+            binding.mainHeader.tabLayout,
+            binding.homeViewpager,
+            true
+        ) { tab, position ->
             when (position) {
                 0 -> tab.text = getString(R.string.bachelor)
                 1 -> tab.text = getString(R.string.scholarship)
@@ -72,19 +76,25 @@ class NoticeFragment : Fragment() {
         binding.mainHeader.inventoryImg.setOnClickListener {
             val intent = Intent(requireActivity(), NoticeStorageActivity::class.java)
             startActivity(intent)
-            requireActivity().overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+            requireActivity().overridePendingTransition(
+                R.anim.anim_slide_right_enter,
+                R.anim.anim_stay_exit
+            )
         }
 
         binding.mainHeader.bellImg.setOnClickListener {
             val intent = Intent(requireActivity(), NotificationActivity::class.java)
             startActivity(intent)
-            requireActivity().overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+            requireActivity().overridePendingTransition(
+                R.anim.anim_slide_right_enter,
+                R.anim.anim_stay_exit
+            )
         }
     }
 
-    private fun observeData(){
+    private fun observeData() {
         viewModel.pushCount.observe(viewLifecycleOwner) {
-            when (it)  {
+            when (it) {
                 0 -> {
                     binding.mainHeader.notiCountBt.visibility = View.GONE
                 }
@@ -94,7 +104,8 @@ class NoticeFragment : Fragment() {
                 }
                 else -> {
                     binding.mainHeader.notiCountBt.visibility = View.VISIBLE
-                    binding.mainHeader.notiCountBt.text = getString(R.string.push_notification_max_count)
+                    binding.mainHeader.notiCountBt.text =
+                        getString(R.string.push_notification_max_count)
                 }
             }
         }
@@ -103,7 +114,7 @@ class NoticeFragment : Fragment() {
     private fun getFcmToken() {
         lifecycleScope.launch {
             firebaseMessaging.token.addOnCompleteListener { task ->
-                if(!task.isSuccessful){
+                if (!task.isSuccessful) {
                     Timber.e("Firebase instanceId fail : ${task.exception}")
                     return@addOnCompleteListener
                 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/NoticeViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/NoticeViewModel.kt
@@ -16,12 +16,12 @@ import javax.inject.Inject
 class NoticeViewModel @Inject constructor(
     private val noticeRepository: NoticeRepository,
     private val pushRepository: PushRepository
-): ViewModel() {
+) : ViewModel() {
 
     private val disposable = CompositeDisposable()
 
     private val _pushCount = MutableLiveData<Int>()
-    val pushCount : LiveData<Int>
+    val pushCount: LiveData<Int>
         get() = _pushCount
 
     init {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/HomeBaseFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/HomeBaseFragment.kt
@@ -27,8 +27,13 @@ abstract class HomeBaseFragment : Fragment() {
 
     private val noticeViewModel by viewModels<NoticeViewModel>({ requireParentFragment() })
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_home_category, container,false)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding =
+            DataBindingUtil.inflate(inflater, R.layout.fragment_home_category, container, false)
         binding.lifecycleOwner = this
         return binding.root
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/NoticeViewHolder.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/NoticeViewHolder.kt
@@ -29,10 +29,16 @@ class NoticeViewHolder(
     private fun setupTag(tagList: List<String>) {
         val colors: MutableList<IntArray> = arrayListOf()
         val color = intArrayOf(
-            ContextCompat.getColor(binding.root.context, R.color.kus_secondary_gray), //tag background color
+            ContextCompat.getColor(
+                binding.root.context,
+                R.color.kus_secondary_gray
+            ), //tag background color
             Color.TRANSPARENT, //tag border color
             Color.WHITE, //tag text color
-            ContextCompat.getColor(binding.root.context, R.color.kus_background) //tag selected background color
+            ContextCompat.getColor(
+                binding.root.context,
+                R.color.kus_background
+            ) //tag selected background color
         )
 
         for (item in tagList) {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage0_Bachelor/BachelorFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage0_Bachelor/BachelorFragment.kt
@@ -14,7 +14,7 @@ class BachelorFragment : HomeBaseFragment() {
     private val viewModel by viewModels<BachelorViewModel>()
 
     @Inject
-    lateinit var analytics : EventAnalytics
+    lateinit var analytics: EventAnalytics
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage0_Bachelor/BachelorViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage0_Bachelor/BachelorViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class BachelorViewModel @Inject constructor(
     private val repository: NoticeRepository
-): ViewModel() {
+) : ViewModel() {
 
     private var currentNoticeResult: Flowable<PagingData<Notice>>? = null
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage1_Scholarship/ScholarshipFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage1_Scholarship/ScholarshipFragment.kt
@@ -7,7 +7,7 @@ import com.ku_stacks.ku_ring.ui.main.notice.category.HomeBaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class ScholarshipFragment: HomeBaseFragment() {
+class ScholarshipFragment : HomeBaseFragment() {
 
     private val viewModel by viewModels<ScholarshipViewModel>()
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage1_Scholarship/ScholarshipViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage1_Scholarship/ScholarshipViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ScholarshipViewModel @Inject constructor(
     private val repository: NoticeRepository
-): ViewModel() {
+) : ViewModel() {
 
     private var currentNoticeResult: Flowable<PagingData<Notice>>? = null
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage2_employ/EmployFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage2_employ/EmployFragment.kt
@@ -7,7 +7,7 @@ import com.ku_stacks.ku_ring.ui.main.notice.category.HomeBaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class EmployFragment : HomeBaseFragment(){
+class EmployFragment : HomeBaseFragment() {
 
     private val viewModel by viewModels<EmployViewModel>()
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage2_employ/EmployViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage2_employ/EmployViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class EmployViewModel @Inject constructor(
     private val repository: NoticeRepository
-): ViewModel() {
+) : ViewModel() {
 
     private var currentNoticeResult: Flowable<PagingData<Notice>>? = null
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage3_nation/NationFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage3_nation/NationFragment.kt
@@ -7,7 +7,7 @@ import com.ku_stacks.ku_ring.ui.main.notice.category.HomeBaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class NationFragment : HomeBaseFragment(){
+class NationFragment : HomeBaseFragment() {
 
     private val viewModel by viewModels<NationViewModel>()
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage3_nation/NationViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage3_nation/NationViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NationViewModel @Inject constructor(
     private val repository: NoticeRepository
-): ViewModel() {
+) : ViewModel() {
 
     private var currentNoticeResult: Flowable<PagingData<Notice>>? = null
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage4_Student/StudentFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage4_Student/StudentFragment.kt
@@ -7,7 +7,7 @@ import com.ku_stacks.ku_ring.ui.main.notice.category.HomeBaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class StudentFragment : HomeBaseFragment(){
+class StudentFragment : HomeBaseFragment() {
 
     private val viewModel by viewModels<StudentViewModel>()
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage4_Student/StudentViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage4_Student/StudentViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class StudentViewModel @Inject constructor(
     private val repository: NoticeRepository
-): ViewModel() {
+) : ViewModel() {
 
     private var currentNoticeResult: Flowable<PagingData<Notice>>? = null
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage5_Industry/IndustryFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage5_Industry/IndustryFragment.kt
@@ -7,7 +7,7 @@ import com.ku_stacks.ku_ring.ui.main.notice.category.HomeBaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class IndustryFragment : HomeBaseFragment(){
+class IndustryFragment : HomeBaseFragment() {
 
     private val viewModel by viewModels<IndustryViewModel>()
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage5_Industry/IndustryViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage5_Industry/IndustryViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class IndustryViewModel @Inject constructor(
     private val repository: NoticeRepository
-): ViewModel() {
+) : ViewModel() {
 
     private var currentNoticeResult: Flowable<PagingData<Notice>>? = null
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage6_Nornal/NormalViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage6_Nornal/NormalViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NormalViewModel @Inject constructor(
     private val repository: NoticeRepository
-): ViewModel() {
+) : ViewModel() {
 
     private var currentNoticeResult: Flowable<PagingData<Notice>>? = null
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage7_Library/LibraryFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage7_Library/LibraryFragment.kt
@@ -7,7 +7,7 @@ import com.ku_stacks.ku_ring.ui.main.notice.category.HomeBaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class LibraryFragment : HomeBaseFragment(){
+class LibraryFragment : HomeBaseFragment() {
 
     private val viewModel by viewModels<LibraryViewModel>()
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage7_Library/LibraryViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/stage7_Library/LibraryViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
     private val repository: NoticeRepository
-): ViewModel() {
+) : ViewModel() {
 
     private var currentNoticeResult: Flowable<PagingData<Notice>>? = null
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/SearchFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/SearchFragment.kt
@@ -68,7 +68,11 @@ class SearchFragment : Fragment() {
         val pagerAdapter = SearchPagerAdapter(childFragmentManager, lifecycle)
         binding.searchViewpager.adapter = pagerAdapter
         binding.searchViewpager.registerOnPageChangeCallback(pageChangeCallback)
-        TabLayoutMediator(binding.searchTabLayout, binding.searchViewpager, false) { tab, position ->
+        TabLayoutMediator(
+            binding.searchTabLayout,
+            binding.searchViewpager,
+            false
+        ) { tab, position ->
             when (position) {
                 0 -> tab.text = "공지"
                 1 -> tab.text = "교직원"
@@ -80,7 +84,9 @@ class SearchFragment : Fragment() {
         binding.searchKeywordEt.addTextChangedListener(object : TextWatcher {
             var lastEditTime = 0L
 
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) =
+                Unit
+
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
             override fun afterTextChanged(s: Editable?) {
                 synchronized(this) {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/SearchViewModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/SearchViewModel.kt
@@ -48,8 +48,8 @@ class SearchViewModel @Inject constructor(
 
     fun searchStaff(keyword: String) {
         Timber.e("in searchStaff -> isOpen : ${searchClient.isOpen()}, isPreparing: ${searchClient.isPreparing()}")
-        if(!searchClient.isOpen()){
-            if(!searchClient.isPreparing()) {
+        if (!searchClient.isOpen()) {
+            if (!searchClient.isPreparing()) {
                 connectWebSocket()
             }
             searchClient.setLastKeyword(keyword)
@@ -60,8 +60,8 @@ class SearchViewModel @Inject constructor(
 
     fun searchNotice(keyword: String) {
         Timber.e("in searchNotice -> isOpen : ${searchClient.isOpen()}, isPreparing: ${searchClient.isPreparing()}")
-        if(!searchClient.isOpen()){
-            if(!searchClient.isPreparing()) {
+        if (!searchClient.isOpen()) {
+            if (!searchClient.isPreparing()) {
                 connectWebSocket()
             }
             searchClient.setLastKeyword(keyword)
@@ -120,8 +120,8 @@ class SearchViewModel @Inject constructor(
     }
 
     fun connectWebSocketIfDisconnected() {
-        if(!searchClient.isOpen()){
-            if(!searchClient.isPreparing()) {
+        if (!searchClient.isOpen()) {
+            if (!searchClient.isPreparing()) {
                 connectWebSocket()
             }
         }
@@ -134,8 +134,8 @@ class SearchViewModel @Inject constructor(
                 .map { searchClient.makeHeartBeat() }
                 .repeat()
                 .subscribeOn(Schedulers.io())
-                .doOnError{Timber.e("make heartbeat failed")}
-                .subscribe ({
+                .doOnError { Timber.e("make heartbeat failed") }
+                .subscribe({
                     Timber.e("make heartbeat success")
                 }, {
                     Timber.e("make heartbeat failed : $it")

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/fragment_notice/SearchNoticeFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/fragment_notice/SearchNoticeFragment.kt
@@ -17,14 +17,19 @@ import com.ku_stacks.ku_ring.ui.notice_webview.NoticeWebActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class SearchNoticeFragment: Fragment() {
+class SearchNoticeFragment : Fragment() {
 
     private lateinit var binding: FragmentSearchNoticeBinding
     private val searchViewModel by viewModels<SearchViewModel>({ requireParentFragment() })
     private lateinit var searchNoticeAdapter: SearchNoticeAdapter
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_search_notice, container, false)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding =
+            DataBindingUtil.inflate(inflater, R.layout.fragment_search_notice, container, false)
         binding.lifecycleOwner = this
         return binding.root
     }
@@ -60,6 +65,9 @@ class SearchNoticeFragment: Fragment() {
     private fun startNoticeActivity(notice: Notice) {
         val intent = NoticeWebActivity.createIntent(requireContext(), notice)
         startActivity(intent)
-        requireActivity().overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+        requireActivity().overridePendingTransition(
+            R.anim.anim_slide_right_enter,
+            R.anim.anim_stay_exit
+        )
     }
 }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/fragment_staff/SearchStaffFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/fragment_staff/SearchStaffFragment.kt
@@ -17,14 +17,19 @@ import com.ku_stacks.ku_ring.ui.main.search.fragment_staff.dialog.StaffBottomShe
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class SearchStaffFragment: Fragment() {
+class SearchStaffFragment : Fragment() {
 
     private lateinit var binding: FragmentSearchStaffBinding
     private val searchViewModel by viewModels<SearchViewModel>({ requireParentFragment() })
     private lateinit var searchStaffAdapter: SearchStaffAdapter
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_search_staff, container, false)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding =
+            DataBindingUtil.inflate(inflater, R.layout.fragment_search_staff, container, false)
         binding.lifecycleOwner = this
         return binding.root
     }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/fragment_staff/dialog/StaffBottomSheet.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/search/fragment_staff/dialog/StaffBottomSheet.kt
@@ -13,9 +13,9 @@ import com.ku_stacks.ku_ring.data.model.Staff
 import com.ku_stacks.ku_ring.databinding.DialogStaffBottomSheetBinding
 import com.ku_stacks.ku_ring.util.showToast
 
-class StaffBottomSheet: BottomSheetDialogFragment() {
+class StaffBottomSheet : BottomSheetDialogFragment() {
 
-    private var _binding : DialogStaffBottomSheetBinding? = null
+    private var _binding: DialogStaffBottomSheetBinding? = null
     private val binding get() = _binding!!
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -42,14 +42,15 @@ class StaffBottomSheet: BottomSheetDialogFragment() {
     private fun setupView(staff: Staff?) {
         staff?.let {
             binding.staffBottomSheetNameTxt.text = staff.name
-            binding.staffBottomSheetDepartmentTxt.text = staff.department +" · "+staff.college
+            binding.staffBottomSheetDepartmentTxt.text = staff.department + " · " + staff.college
             binding.staffBottomSheetEmailTxt.text = "✉ ${staff.email}"
             binding.staffBottomSheetLabTxt.text = "📍 ${staff.lab}"
             binding.staffBottomSheetPhoneTxt.text = "📞 ${staff.phone}"
             binding.staffBottomSheetMajorTxt.text = "📖 ${staff.major}"
 
             binding.staffBottomSheetEmailTxt.setOnClickListener {
-                val clipboardManager = requireContext().getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                val clipboardManager =
+                    requireContext().getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
                 val clipData = ClipData.newPlainText("email", staff.email)
                 clipboardManager.setPrimaryClip(clipData)
 
@@ -57,7 +58,8 @@ class StaffBottomSheet: BottomSheetDialogFragment() {
             }
 
             binding.staffBottomSheetPhoneTxt.setOnClickListener {
-                val clipboardManager = requireContext().getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                val clipboardManager =
+                    requireContext().getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
                 val clipData = ClipData.newPlainText("phone number", staff.phone)
                 clipboardManager.setPrimaryClip(clipData)
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/setting/SettingFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/setting/SettingFragment.kt
@@ -45,7 +45,10 @@ class SettingFragment : Fragment() {
         binding.subscribeLayout.subscribeNoticeLayout.setOnClickListener {
             val intent = Intent(requireContext(), EditSubscriptionActivity::class.java)
             startActivity(intent)
-            requireActivity().overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+            requireActivity().overridePendingTransition(
+                R.anim.anim_slide_right_enter,
+                R.anim.anim_stay_exit
+            )
         }
         binding.subscribeLayout.subscribeExtSwitch.setOnCheckedChangeListener { _, isChecked ->
             viewModel.setExtNotificationAllowed(isChecked)
@@ -68,14 +71,20 @@ class SettingFragment : Fragment() {
             val intent = Intent(requireContext(), OssLicensesMenuActivity::class.java)
             startActivity(intent)
             OssLicensesMenuActivity.setActivityTitle(getString(R.string.open_source_license))
-            requireActivity().overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+            requireActivity().overridePendingTransition(
+                R.anim.anim_slide_right_enter,
+                R.anim.anim_stay_exit
+            )
         }
 
         /** feedback layout */
         binding.feedbackLayout.feedbackSendLayout.setOnClickListener {
             val intent = Intent(requireContext(), FeedbackActivity::class.java)
             startActivity(intent)
-            requireActivity().overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+            requireActivity().overridePendingTransition(
+                R.anim.anim_slide_right_enter,
+                R.anim.anim_stay_exit
+            )
         }
     }
 
@@ -83,7 +92,10 @@ class SettingFragment : Fragment() {
         val intent = Intent(requireContext(), NotionViewActivity::class.java)
         intent.putExtra(NotionViewActivity.NOTION_URL, url)
         startActivity(intent)
-        requireActivity().overridePendingTransition(R.anim.anim_slide_right_enter, R.anim.anim_stay_exit)
+        requireActivity().overridePendingTransition(
+            R.anim.anim_slide_right_enter,
+            R.anim.anim_stay_exit
+        )
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationActivity.kt
@@ -25,7 +25,7 @@ import javax.inject.Inject
 class NotificationActivity : AppCompatActivity() {
 
     @Inject
-    lateinit var analytics : EventAnalytics
+    lateinit var analytics: EventAnalytics
 
     private lateinit var binding: ActivityNotificationBinding
     private val viewModel by viewModels<NotificationViewModel>()

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationAdapter.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/NotificationAdapter.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.ku_stacks.ku_ring.R
-import com.ku_stacks.ku_ring.data.model.Push
 import com.ku_stacks.ku_ring.databinding.ItemDateBinding
 import com.ku_stacks.ku_ring.databinding.ItemNotificationBinding
 import com.ku_stacks.ku_ring.ui.my_notification.diff_callback.NotificationDiffCallback
@@ -15,12 +14,11 @@ import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushDataUiModel
 import com.ku_stacks.ku_ring.ui.my_notification.ui_model.PushDateHeaderUiModel
 import com.ku_stacks.ku_ring.ui.my_notification.viewholder.DateViewHolder
 import com.ku_stacks.ku_ring.ui.my_notification.viewholder.NotificationViewHolder
-import timber.log.Timber
 
 class NotificationAdapter(
     private val itemClick: (PushContentUiModel) -> Unit,
     private val onBindItem: (PushContentUiModel) -> Unit
-): ListAdapter<PushDataUiModel, NotificationAdapter.ViewHolder>(
+) : ListAdapter<PushDataUiModel, NotificationAdapter.ViewHolder>(
     NotificationDiffCallback()
 ) {
     abstract class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
@@ -28,12 +26,14 @@ class NotificationAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return when (viewType) {
             NOTIFICATION_CONTENT -> {
-                val view = LayoutInflater.from(parent.context).inflate(R.layout.item_notification, parent, false)
+                val view = LayoutInflater.from(parent.context)
+                    .inflate(R.layout.item_notification, parent, false)
                 val binding = ItemNotificationBinding.bind(view)
                 NotificationViewHolder(binding, itemClick)
             }
             NOTIFICATION_DATE -> {
-                val view = LayoutInflater.from(parent.context).inflate(R.layout.item_date, parent, false)
+                val view =
+                    LayoutInflater.from(parent.context).inflate(R.layout.item_date, parent, false)
                 val binding = ItemDateBinding.bind(view)
                 DateViewHolder(binding)
             }

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/ui_model/PushUiModel.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/ui_model/PushUiModel.kt
@@ -2,11 +2,11 @@ package com.ku_stacks.ku_ring.ui.my_notification.ui_model
 
 sealed class PushDataUiModel
 
-data class PushDateHeaderUiModel (
+data class PushDateHeaderUiModel(
     val postedDate: String
 ) : PushDataUiModel()
 
-data class PushContentUiModel (
+data class PushContentUiModel(
     val articleId: String,
     val categoryKor: String,
     val postedDate: String,

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/viewholder/NotificationViewHolder.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/my_notification/viewholder/NotificationViewHolder.kt
@@ -24,10 +24,14 @@ class NotificationViewHolder(
     private fun setupTag(tagList: List<String>) {
         val colors: MutableList<IntArray> = arrayListOf()
         val color = intArrayOf(
-            ContextCompat.getColor(binding.root.context, R.color.kus_secondary_gray), //tag background color
+            ContextCompat.getColor(
+                binding.root.context,
+                R.color.kus_secondary_gray
+            ), //tag background color
             Color.TRANSPARENT, //tag border color
             Color.WHITE, //tag text color
-            Color.TRANSPARENT) //tag selected background color
+            Color.TRANSPARENT
+        ) //tag selected background color
 
         for (item in tagList) {
             colors.add(color)

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/on_boarding/OnBoardingActivity.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/on_boarding/OnBoardingActivity.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class OnBoardingActivity : AppCompatActivity() {
     @Inject
-    lateinit var analytics : EventAnalytics
+    lateinit var analytics: EventAnalytics
 
     @Inject
     lateinit var pref: PreferenceUtil

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/ContextExt.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/ContextExt.kt
@@ -19,7 +19,12 @@ fun Context.makeDialog(title: String? = null, description: String? = null): Kuri
     }
 }
 
-fun Context.makeDialog(title: String? = null, description: String? = null, leftText: String?, rightText: String): KuringDialog {
+fun Context.makeDialog(
+    title: String? = null,
+    description: String? = null,
+    leftText: String?,
+    rightText: String
+): KuringDialog {
     return KuringDialog(this).apply {
         setText(_title = title, _description = description)
         setButtonText(leftText = leftText, rightText = rightText)

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/DateUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/DateUtil.kt
@@ -5,7 +5,7 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 object DateUtil {
-    
+
     @JvmStatic
     fun getToday(): String {
         val simpleDateFormat = SimpleDateFormat("yyyyMMdd", Locale.KOREA)

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/StringUtil.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/StringUtil.kt
@@ -2,6 +2,6 @@ package com.ku_stacks.ku_ring.util
 
 import com.ku_stacks.ku_ring.BuildConfig
 
-infix fun String.or(that: String): String =  if (BuildConfig.DEBUG) this else that
+infix fun String.or(that: String): String = if (BuildConfig.DEBUG) this else that
 
 fun String.isOnlyAlphabets() = matches("[a-zA-Z]*$".toRegex())

--- a/app/src/main/java/com/ku_stacks/ku_ring/util/modified_external_library/AppearanceAnimator.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/util/modified_external_library/AppearanceAnimator.kt
@@ -9,8 +9,10 @@ object AppearanceAnimator {
 
     @Synchronized
     fun expand(v: View) {
-        val matchParentMeasureSpec = View.MeasureSpec.makeMeasureSpec((v.parent as View).width, View.MeasureSpec.EXACTLY)
-        val wrapContentMeasureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        val matchParentMeasureSpec =
+            View.MeasureSpec.makeMeasureSpec((v.parent as View).width, View.MeasureSpec.EXACTLY)
+        val wrapContentMeasureSpec =
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
         v.measure(matchParentMeasureSpec, wrapContentMeasureSpec)
         val targetHeight = v.measuredHeight
 
@@ -29,14 +31,17 @@ object AppearanceAnimator {
         }
 
         // Expansion speed of 1dp/ms
-        a.duration = (duration * (targetHeight / v.context.resources.displayMetrics.density).toInt()).toLong()
+        a.duration =
+            (duration * (targetHeight / v.context.resources.displayMetrics.density).toInt()).toLong()
         v.startAnimation(a)
     }
 
     @Synchronized
     fun expand(v: View, targetHeight: Int) {
-        val matchParentMeasureSpec = View.MeasureSpec.makeMeasureSpec((v.parent as View).width, View.MeasureSpec.EXACTLY)
-        val wrapContentMeasureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        val matchParentMeasureSpec =
+            View.MeasureSpec.makeMeasureSpec((v.parent as View).width, View.MeasureSpec.EXACTLY)
+        val wrapContentMeasureSpec =
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
         v.measure(matchParentMeasureSpec, wrapContentMeasureSpec)
 
         // Older versions of android (pre API 21) cancel animations for views with a height of 0.
@@ -54,7 +59,8 @@ object AppearanceAnimator {
         }
 
         // Expansion speed of 1dp/ms
-        a.duration = (duration * (targetHeight / v.context.resources.displayMetrics.density).toInt()).toLong()
+        a.duration =
+            (duration * (targetHeight / v.context.resources.displayMetrics.density).toInt()).toLong()
         v.startAnimation(a)
     }
 
@@ -66,7 +72,8 @@ object AppearanceAnimator {
                 if (interpolatedTime == 1f) {
                     v.visibility = View.GONE
                 } else {
-                    v.layoutParams.height = initialHeight - (initialHeight * interpolatedTime).toInt()
+                    v.layoutParams.height =
+                        initialHeight - (initialHeight * interpolatedTime).toInt()
                     v.requestLayout()
                 }
             }
@@ -77,7 +84,8 @@ object AppearanceAnimator {
         }
 
         // Collapse speed of 1dp/ms
-        a.duration = (duration * (initialHeight / v.context.resources.displayMetrics.density).toInt()).toLong()
+        a.duration =
+            (duration * (initialHeight / v.context.resources.displayMetrics.density).toInt()).toLong()
         v.startAnimation(a)
     }
 }

--- a/app/src/test/java/com/ku_stacks/ku_ring/TestingLiveDataExt.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/TestingLiveDataExt.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Observer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+
 /**
  * Gets the value of a [LiveData] or waits for it to have one, with a timeout.
  *

--- a/app/src/test/java/com/ku_stacks/ku_ring/paging_source/NoticePagingSourceTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/paging_source/NoticePagingSourceTest.kt
@@ -39,25 +39,27 @@ class NoticePagingSourceTest {
             .await()
             .assertNoErrors()
             .assertValueCount(1)
-            .assertValue(LoadResult.Page<Int, Notice>(
-                data = listOf(
-                    Notice(
-                        postedDate = "20220203",
-                        subject = "2022학년도 1학기 재입학 합격자 유의사항 안내",
-                        category = "bachelor",
-                        url = "https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?id=5b4a11b",
-                        articleId = "5b4a11b",
-                        isNew = false,
-                        isRead = false,
-                        isSubscribing = false,
-                        isSaved = false,
-                        isReadOnStorage = false,
-                        tag = emptyList()
-                    )
-                ),
-                prevKey = null,
-                nextKey = 20
-            ))
+            .assertValue(
+                LoadResult.Page<Int, Notice>(
+                    data = listOf(
+                        Notice(
+                            postedDate = "20220203",
+                            subject = "2022학년도 1학기 재입학 합격자 유의사항 안내",
+                            category = "bachelor",
+                            url = "https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?id=5b4a11b",
+                            articleId = "5b4a11b",
+                            isNew = false,
+                            isRead = false,
+                            isSubscribing = false,
+                            isSaved = false,
+                            isReadOnStorage = false,
+                            tag = emptyList()
+                        )
+                    ),
+                    prevKey = null,
+                    nextKey = 20
+                )
+            )
 
         Mockito.verify(client, Mockito.atLeastOnce()).fetchNoticeList("bch", 0, 20)
     }
@@ -75,25 +77,27 @@ class NoticePagingSourceTest {
             .await()
             .assertNoErrors()
             .assertValueCount(1)
-            .assertValue(LoadResult.Page<Int, Notice>(
-                data = listOf(
-                    Notice(
-                        postedDate = "20220203",
-                        subject = "2022학년도 1학기 재입학 합격자 유의사항 안내",
-                        category = "bachelor",
-                        url = "https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?id=5b4a11b",
-                        articleId = "5b4a11b",
-                        isNew = false,
-                        isRead = false,
-                        isSubscribing = false,
-                        isSaved = false,
-                        isReadOnStorage = false,
-                        tag = emptyList()
-                    )
-                ),
-                prevKey = 0,
-                nextKey = 40
-            ))
+            .assertValue(
+                LoadResult.Page<Int, Notice>(
+                    data = listOf(
+                        Notice(
+                            postedDate = "20220203",
+                            subject = "2022학년도 1학기 재입학 합격자 유의사항 안내",
+                            category = "bachelor",
+                            url = "https://www.konkuk.ac.kr/do/MessageBoard/ArticleRead.do?id=5b4a11b",
+                            articleId = "5b4a11b",
+                            isNew = false,
+                            isRead = false,
+                            isSubscribing = false,
+                            isSaved = false,
+                            isReadOnStorage = false,
+                            tag = emptyList()
+                        )
+                    ),
+                    prevKey = 0,
+                    nextKey = 40
+                )
+            )
 
         Mockito.verify(client, Mockito.atLeastOnce()).fetchNoticeList("bch", 20, 20)
     }

--- a/app/src/test/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/repository/NoticeRepositoryTest.kt
@@ -57,7 +57,8 @@ class NoticeRepositoryTest {
     fun `updateNotice Test`() {
         // given
         val mockData = mockReadNoticeEntity()
-        Mockito.`when`(dao.updateNoticeAsRead(mockData.articleId, mockData.category)).thenReturn(Completable.complete())
+        Mockito.`when`(dao.updateNoticeAsRead(mockData.articleId, mockData.category))
+            .thenReturn(Completable.complete())
 
         // when + then
         repository.updateNoticeToBeRead(mockData.articleId, mockData.category)

--- a/app/src/test/java/com/ku_stacks/ku_ring/repository/PushRepositoryTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/repository/PushRepositoryTest.kt
@@ -42,7 +42,8 @@ class PushRepositoryTest {
     fun `update Notification As Old Test`() {
         // given
         val mockData = mockPushEntity()
-        Mockito.`when`(dao.updateNotificationAsOld(mockData.articleId, false)).thenReturn(Completable.complete())
+        Mockito.`when`(dao.updateNotificationAsOld(mockData.articleId, false))
+            .thenReturn(Completable.complete())
 
         // when + then
         repository.updateNotificationAsOld(mockData.articleId)
@@ -68,7 +69,8 @@ class PushRepositoryTest {
     fun `delete notification Test`() {
         //given
         val mockData = mockPushEntity()
-        Mockito.`when`(dao.deleteNotification(mockData.articleId)).thenReturn(Completable.complete())
+        Mockito.`when`(dao.deleteNotification(mockData.articleId))
+            .thenReturn(Completable.complete())
 
         // when + then
         dao.deleteNotification(mockData.articleId)

--- a/app/src/test/java/com/ku_stacks/ku_ring/repository/SubscribeRepositoryTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/repository/SubscribeRepositoryTest.kt
@@ -17,7 +17,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -45,7 +44,8 @@ class SubscribeRepositoryTest {
     @Test
     fun `fetch Subscription From Remote Test`() {
         // given
-        val mockToken = "AAAAn6eQM_Y:APA91bES4rjrFwPY5i_Hz-kT0u32SzIUxreYm9qaQHZeYKGGV_BmHZNJhHvlDjyQA6LveNdxCVrwzsq78jgsnCw8OumbtM5L3cc17XgdqZ_dlpsPzR7TlJwBFTXRFLPst663IeX27sb0"
+        val mockToken =
+            "AAAAn6eQM_Y:APA91bES4rjrFwPY5i_Hz-kT0u32SzIUxreYm9qaQHZeYKGGV_BmHZNJhHvlDjyQA6LveNdxCVrwzsq78jgsnCw8OumbtM5L3cc17XgdqZ_dlpsPzR7TlJwBFTXRFLPst663IeX27sb0"
         val mockSubscribeList = mockSubscribeListResponse()
 
         Mockito.`when`(client.fetchSubscribe(mockToken)).thenReturn(Single.just(mockSubscribeList))

--- a/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/NotificationViewModelTest.kt
+++ b/app/src/test/java/com/ku_stacks/ku_ring/viewmodel_usecase/NotificationViewModelTest.kt
@@ -7,18 +7,17 @@ import com.ku_stacks.ku_ring.MockUtil.mockPushEntity
 import com.ku_stacks.ku_ring.data.mapper.toPushList
 import com.ku_stacks.ku_ring.data.mapper.toPushUiModelList
 import com.ku_stacks.ku_ring.getOrAwaitValue
-import com.ku_stacks.ku_ring.repository.NoticeRepository
 import com.ku_stacks.ku_ring.repository.PushRepository
 import com.ku_stacks.ku_ring.ui.my_notification.NotificationViewModel
 import com.ku_stacks.ku_ring.util.PreferenceUtil
 import io.reactivex.rxjava3.core.Completable
 import io.reactivex.rxjava3.core.Flowable
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.*
-import org.junit.Assert.assertEquals
 import org.mockito.Mockito
+import org.mockito.Mockito.*
 
 class NotificationViewModelTest {
 
@@ -54,7 +53,8 @@ class NotificationViewModelTest {
     fun `updateNotification As Old Test`() {
         // given
         val mockData = mockPushEntity()
-        Mockito.`when`(pushRepository.updateNotificationAsOld(mockData.articleId)).thenReturn(Completable.complete())
+        Mockito.`when`(pushRepository.updateNotificationAsOld(mockData.articleId))
+            .thenReturn(Completable.complete())
 
         // when
         viewModel.updateNotificationToBeOld(mockData.articleId)


### PR DESCRIPTION
Android Studio에서 `ctrl+alt+L`을 누르면 실행되는 Reformat code를 테스트 포함 모든 코드에 적용했습니다. Options는 Optimize Imports만을 체크했습니다. 변경사항은 읽어보지 않으셔도 될 듯합니다.

다만 1. 포매팅을 해야만 하느냐? 2. 그럼 이제 모두가 같은 포맷을 써야 하지 않겠느냐? 라는 의문이 들 수 있는데요

1) 저는 코딩하면서 `ctrl+alt+L`을 누르는 습관이 있는데, 이러면 지금 작업한 내용과 관련없는 다른 부분이 포매팅됩니다. 지금까지는 일일이 rollback했는데 ^^;; 본격적으로 리팩토링하기 전에 먼저 포맷을 정리하고 싶었습니다.
2) Android Studio에서 Kotlin 파일에 사용할 code format을 XML 포맷으로 export할 수 있습니다. 이 파일을 import하면 같은 포맷을 사용할 수 있습니다.

어떻게 생각하시나요?