### PR TITLE
[수정] debug API의 base url을 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ android {
                     appName : "@string/app_name_debug",
                     appIcon : "@drawable/ic_ku_ring_launcher_dev"
             ]
-            buildConfigField "String", "API_BASE_URL", "\"http://ec2-43-207-30-148.ap-northeast-1.compute.amazonaws.com/api/v1/\""
+            buildConfigField "String", "API_BASE_URL", "\"http://ec2-13-113-178-212.ap-northeast-1.compute.amazonaws.com/api/v1/\""
             buildConfigField "String", "WEB_SOCKET_URL", "\"wss://kuring-dev.herokuapp.com/kuring/search\""
             buildConfigField "String", "KURING_CAMPUS_OPEN_CHANNEL_URL", "\"kuring_main_anonymous\""
 


### PR DESCRIPTION
그렇습니다.

`WEB_SOCKET_URL`은 어차피 웹소켓이 곧 제거될 예정이라 그대로 두었습니다.