### PR TITLE
[제안] fragment 에 데이터를 생성자 대신 bundle 로 전달

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/CategoryPagerAdapter.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/CategoryPagerAdapter.kt
@@ -13,7 +13,7 @@ class CategoryPagerAdapter(fm: FragmentManager, lc: Lifecycle) : FragmentStateAd
      * (Fragment 가 destroy 될 때 참조가 남음)
      */
     private val items = listOf("bch", "sch", "emp", "nat", "stu", "ind", "nor", "lib")
-        .map { shortCategory -> { HomeBaseFragment(shortCategory) } }
+        .map { shortCategory -> { HomeBaseFragment.newInstance(shortCategory) } }
 
     override fun getItemCount() = items.size
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/HomeBaseFragment.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/ui/main/notice/category/HomeBaseFragment.kt
@@ -19,9 +19,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
-class HomeBaseFragment(private val shortCategory: String) : Fragment() {
+class HomeBaseFragment : Fragment() {
     private val disposable = CompositeDisposable()
 
     private lateinit var binding: FragmentHomeCategoryBinding
@@ -92,6 +93,13 @@ class HomeBaseFragment(private val shortCategory: String) : Fragment() {
     }
 
     private fun subscribeNotices() {
+        val shortCategory = arguments?.getString(SHORT_CATEGORY)
+
+        if (shortCategory.isNullOrEmpty()) {
+            Timber.e("shortCategory is null")
+            return
+        }
+
         val noticeDisposable = noticeViewModel.getNotices(shortCategory, lifecycleScope).subscribe {
             pagingAdapter.submitData(lifecycle, it)
         }
@@ -124,5 +132,18 @@ class HomeBaseFragment(private val shortCategory: String) : Fragment() {
             disposable.dispose()
         }
         super.onDestroyView()
+    }
+
+    companion object {
+        private const val SHORT_CATEGORY = "SHORT_CATEGORY"
+
+        fun newInstance(shortCategory: String): HomeBaseFragment {
+            val args = Bundle().apply {
+                putString(SHORT_CATEGORY, shortCategory)
+            }
+            return HomeBaseFragment().apply {
+                arguments = args
+            }
+        }
     }
 }


### PR DESCRIPTION
https://github.com/KU-Stacks/KU-Ring-Android/pull/28#discussion_r1133297538 에서 말씀드렸던, Fragment에 데이터를 Bundle로 전달하도록 수정한 PR입니다.

#### 변경 내용
- fragment에 데이터를 생성자 대신 bundle로 전달