### PR TITLE
[추가] 검색어 모두 지우기 기능 추가

### DIFF
--- a/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearEditText.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearEditText.kt
@@ -1,0 +1,81 @@
+package com.ku_stacks.ku_ring.customview
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import androidx.appcompat.widget.AppCompatEditText
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.widget.addTextChangedListener
+import com.ku_stacks.ku_ring.R
+
+class ClearEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusChangeListener {
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int)
+        : super(context, attrs, defStyleAttr)
+
+    private lateinit var clearDrawable: Drawable
+
+    @JvmField
+    var onFocusChangeListener: OnFocusChangeListener? = null
+
+    @JvmField
+    var onTouchListener: OnTouchListener? = null
+
+    init {
+        initView()
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun initView() {
+        val rawDrawable = ContextCompat.getDrawable(context, R.drawable.ic_close)!!
+        clearDrawable = DrawableCompat.wrap(rawDrawable)
+
+        DrawableCompat.setTintList(clearDrawable, hintTextColors)
+        clearDrawable.setBounds(0, 0, clearDrawable.intrinsicWidth, clearDrawable.intrinsicHeight)
+
+        addTextChangedListener { editable ->
+            val isVisible = editable?.isNotEmpty() ?: false
+            setClearDrawableVisibility(isVisible)
+        }
+
+        super.setOnTouchListener(this)
+        super.setOnFocusChangeListener(this)
+    }
+
+    override fun onTouch(view: View?, motionEvent: MotionEvent?): Boolean {
+        motionEvent?.x?.let { x ->
+            if (clearDrawable.isVisible && x > width - paddingRight - clearDrawable.intrinsicWidth) {
+                if (motionEvent.action == MotionEvent.ACTION_UP) {
+                    error = null
+                    text = null
+                }
+                return true
+            }
+        }
+
+        return onTouchListener?.onTouch(view, motionEvent) ?: false
+    }
+
+    override fun onFocusChange(view: View?, hasFocus: Boolean) {
+        val newVisibility = if (hasFocus) {
+            text?.isNotEmpty() == true
+        } else {
+            false
+        }
+        setClearDrawableVisibility(newVisibility)
+
+        onFocusChangeListener?.onFocusChange(view, hasFocus)
+    }
+
+    private fun setClearDrawableVisibility(visible: Boolean) {
+        clearDrawable.setVisible(visible, false)
+        setCompoundDrawables(compoundDrawables[0], null, if (visible) clearDrawable else null, null)
+    }
+
+}

--- a/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
@@ -22,9 +22,6 @@ class ClearableEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusC
     private lateinit var clearDrawable: Drawable
 
     @JvmField
-    var onFocusChangeListener: OnFocusChangeListener? = null
-
-    @JvmField
     var onTouchListener: OnTouchListener? = null
 
     init {
@@ -69,8 +66,6 @@ class ClearableEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusC
             false
         }
         setClearDrawableVisibility(newVisibility)
-
-        onFocusChangeListener?.onFocusChange(view, hasFocus)
     }
 
     private fun setClearDrawableVisibility(visible: Boolean) {

--- a/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
@@ -12,7 +12,7 @@ import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.widget.addTextChangedListener
 import com.ku_stacks.ku_ring.R
 
-class ClearEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusChangeListener {
+class ClearableEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusChangeListener {
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)

--- a/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
@@ -12,7 +12,7 @@ import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.widget.addTextChangedListener
 import com.ku_stacks.ku_ring.R
 
-class ClearableEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusChangeListener {
+class ClearableEditText : AppCompatEditText, View.OnTouchListener {
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
@@ -39,7 +39,6 @@ class ClearableEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusC
         }
 
         super.setOnTouchListener(this)
-        super.setOnFocusChangeListener(this)
     }
 
     override fun onTouch(view: View?, motionEvent: MotionEvent?): Boolean {
@@ -54,15 +53,6 @@ class ClearableEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusC
         }
 
         return false
-    }
-
-    override fun onFocusChange(view: View?, hasFocus: Boolean) {
-        val newVisibility = if (hasFocus) {
-            text?.isNotEmpty() == true
-        } else {
-            false
-        }
-        showOrHideClearDrawable(newVisibility)
     }
 
     private fun showOrHideClearDrawable(visible: Boolean) {

--- a/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
@@ -35,7 +35,7 @@ class ClearableEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusC
 
         addTextChangedListener { editable ->
             val isVisible = editable?.isNotEmpty() ?: false
-            setClearDrawableVisibility(isVisible)
+            showOrHideClearDrawable(isVisible)
         }
 
         super.setOnTouchListener(this)
@@ -62,11 +62,10 @@ class ClearableEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusC
         } else {
             false
         }
-        setClearDrawableVisibility(newVisibility)
+        showOrHideClearDrawable(newVisibility)
     }
 
-    private fun setClearDrawableVisibility(visible: Boolean) {
-        clearDrawable.setVisible(visible, false)
+    private fun showOrHideClearDrawable(visible: Boolean) {
         setCompoundDrawables(compoundDrawables[0], null, if (visible) clearDrawable else null, null)
     }
 

--- a/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
@@ -21,9 +21,6 @@ class ClearableEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusC
 
     private lateinit var clearDrawable: Drawable
 
-    @JvmField
-    var onTouchListener: OnTouchListener? = null
-
     init {
         initView()
     }
@@ -56,7 +53,7 @@ class ClearableEditText : AppCompatEditText, View.OnTouchListener, View.OnFocusC
             }
         }
 
-        return onTouchListener?.onTouch(view, motionEvent) ?: false
+        return false
     }
 
     override fun onFocusChange(view: View?, hasFocus: Boolean) {

--- a/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
+++ b/app/src/main/java/com/ku_stacks/ku_ring/customview/ClearableEditText.kt
@@ -5,14 +5,13 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.MotionEvent
-import android.view.View
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.widget.addTextChangedListener
 import com.ku_stacks.ku_ring.R
 
-class ClearableEditText : AppCompatEditText, View.OnTouchListener {
+class ClearableEditText : AppCompatEditText {
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
@@ -38,21 +37,18 @@ class ClearableEditText : AppCompatEditText, View.OnTouchListener {
             showOrHideClearDrawable(isVisible)
         }
 
-        super.setOnTouchListener(this)
-    }
-
-    override fun onTouch(view: View?, motionEvent: MotionEvent?): Boolean {
-        motionEvent?.x?.let { x ->
-            if (clearDrawable.isVisible && x > width - paddingRight - clearDrawable.intrinsicWidth) {
-                if (motionEvent.action == MotionEvent.ACTION_UP) {
-                    error = null
-                    text = null
+        setOnTouchListener { _, motionEvent ->
+            motionEvent?.x?.let { x ->
+                if (clearDrawable.isVisible && x > width - paddingRight - clearDrawable.intrinsicWidth) {
+                    if (motionEvent.action == MotionEvent.ACTION_UP) {
+                        error = null
+                        text = null
+                    }
+                    return@setOnTouchListener true
                 }
-                return true
             }
+            return@setOnTouchListener false
         }
-
-        return false
     }
 
     private fun showOrHideClearDrawable(visible: Boolean) {

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -29,7 +29,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             tools:text="검색" />
 
-        <com.ku_stacks.ku_ring.customview.ClearEditText
+        <com.ku_stacks.ku_ring.customview.ClearableEditText
             android:id="@+id/search_keyword_et"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -29,7 +29,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             tools:text="검색" />
 
-        <EditText
+        <com.ku_stacks.ku_ring.customview.ClearEditText
             android:id="@+id/search_keyword_et"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
모두 지우기 기능을 지원하는 커스텀 뷰 `ClearableEditText`를 정의한 후, XML에서 `EditText`를 `ClearableEditText`로 교체했습니다.

![image](https://user-images.githubusercontent.com/45386920/227131882-5c3ce818-fa51-4312-9245-3445c43b349c.png)
