### PR TITLE
[수정] 디버깅 API 도메인을 ku-ring.com으로 변경

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,7 @@ android {
                     appName : "@string/app_name_debug",
                     appIcon : "@drawable/ic_ku_ring_launcher_dev"
             ]
-            buildConfigField "String", "API_BASE_URL", "\"http://ec2-13-113-178-212.ap-northeast-1.compute.amazonaws.com/api/\""
+            buildConfigField "String", "API_BASE_URL", "\"http://api-test.ku-ring.com/api/\""
             buildConfigField "String", "KURING_CAMPUS_OPEN_CHANNEL_URL", "\"kuring_main_anonymous\""
 
             applicationIdSuffix '.debug'


### PR DESCRIPTION
디버깅 앱에서 복잡한 aws URL 대신 `api-test.ku-ring.com`을 사용합니다.

끝!