### PR TITLE
fix: 선택된 학과가 없을 때의 학과별 공지 배경색 수정

### DIFF
--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/notice/compose/inner_screen/DepartmentNoticeScreen.kt
@@ -2,34 +2,14 @@ package com.ku_stacks.ku_ring.main.notice.compose.inner_screen
 
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.PullRefreshState
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material.rememberModalBottomSheetState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -84,7 +64,7 @@ internal fun DepartmentNoticeScreen(
 
     when (departmentNoticeScreenState) {
         DepartmentNoticeScreenState.InitialLoading -> {
-            Box(modifier = modifier) {
+            Box(modifier = modifier.background(KuringTheme.colors.background)) {
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             }
         }
@@ -92,7 +72,7 @@ internal fun DepartmentNoticeScreen(
         DepartmentNoticeScreenState.DepartmentsEmpty -> {
             DepartmentEmptyScreen(
                 onNavigateToEditDepartment = onNavigateToEditDepartment,
-                modifier = modifier,
+                modifier = modifier.background(KuringTheme.colors.background),
             )
         }
 


### PR DESCRIPTION
https://kuring.atlassian.net/browse/KURING-222?atlOrigin=eyJpIjoiODliNGQzNDY0NmM2NGUzYWJiNWY3MzdjNzA2NWE2MmEiLCJwIjoiaiJ9

## 요약

학과별 공지 화면에서, 로딩 중 또는 학과를 지정하지 않았을 때 배경색이 지정되지 않던(따라서 하얀색으로 보이던) 문제를 해결했습니다.

### As-is

![image](https://github.com/user-attachments/assets/c9bb2cf5-5854-4d58-97d6-1ac46e10d5ae)

### To-be

![image](https://github.com/user-attachments/assets/a693ac00-e2ca-4528-b010-0f9f785967d8)
