### PR TITLE
kuring-253 동아리 목록 조회 api 추가

### DIFF
--- a/core/util/src/main/java/com/ku_stacks/ku_ring/util/StringUtil.kt
+++ b/core/util/src/main/java/com/ku_stacks/ku_ring/util/StringUtil.kt
@@ -1,5 +1,15 @@
 package com.ku_stacks.ku_ring.util
 
+import kotlinx.datetime.LocalDateTime
+
 infix fun String.or(that: String): String = if (BuildConfig.DEBUG) this else that
 
 fun String.isOnlyAlphabets() = matches("[a-zA-Z]*$".toRegex())
+
+fun String.toLocalDateTimeOrNull(): LocalDateTime? {
+    return try {
+        if (this.isEmpty()) null else LocalDateTime.parse(this)
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/data/club/build.gradle.kts
+++ b/data/club/build.gradle.kts
@@ -2,6 +2,7 @@ import com.ku_stacks.ku_ring.buildlogic.dsl.setNameSpace
 
 plugins {
     kuring("feature")
+    kuringPrimitive("test")
 }
 
 android {
@@ -15,4 +16,9 @@ dependencies {
     implementation(projects.domain.club)
 
     implementation(libs.kotlinx.datetime)
+    implementation(libs.androidx.paging.common.ktx)
+    implementation(libs.androidx.paging.runtime.ktx)
+
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.androidx.paging.testing)
 }

--- a/data/club/src/main/java/com/ku_stacks/ku_ring/club/ClubRepositoryImpl.kt
+++ b/data/club/src/main/java/com/ku_stacks/ku_ring/club/ClubRepositoryImpl.kt
@@ -1,13 +1,26 @@
 package com.ku_stacks.ku_ring.club
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.map
 import com.ku_stacks.ku_ring.club.mapper.toClub
+import com.ku_stacks.ku_ring.club.pagingsource.ClubListRequest
+import com.ku_stacks.ku_ring.club.pagingsource.ClubsPagingSource
+import com.ku_stacks.ku_ring.club.pagingsource.SubscribedClubPagingSource
 import com.ku_stacks.ku_ring.domain.Club
+import com.ku_stacks.ku_ring.domain.ClubCategory
+import com.ku_stacks.ku_ring.domain.ClubDivision
 import com.ku_stacks.ku_ring.domain.club.ClubRepository
 import com.ku_stacks.ku_ring.remote.club.ClubClient
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class ClubRepositoryImpl @Inject constructor(
     private val clubClient: ClubClient,
+    private val clubsFactory: ClubsPagingSource.Factory,
+    private val subscribedClubsFactory: SubscribedClubPagingSource.Factory,
 ) : ClubRepository {
     override suspend fun subscribeClub(clubId: Int): Result<Int> {
         val response = clubClient.subscribeClub(clubId)
@@ -31,5 +44,39 @@ class ClubRepositoryImpl @Inject constructor(
             response.isSuccessAndDataExists -> Result.success(response.data!!.toClub())
             else -> Result.failure(IllegalStateException(response.resultMsg))
         }
+    }
+
+    override fun getClubs(
+        category: ClubCategory,
+        division: ClubDivision,
+        sortBy: String,
+    ): Flow<PagingData<Club>> {
+        return Pager(
+            config = PagingConfig(pageSize = PAGE_SIZE),
+            pagingSourceFactory = {
+                clubsFactory.create(
+                    ClubListRequest(
+                        category = category.name.lowercase(),
+                        division = division.name.lowercase(),
+                        sortBy = sortBy,
+                    )
+                )
+            },
+        ).flow.map { pagingData ->
+            pagingData.map { it.toClub() }
+        }
+    }
+
+    override fun getSubscribedClubs(): Flow<PagingData<Club>> {
+        return Pager(
+            config = PagingConfig(pageSize = PAGE_SIZE),
+            pagingSourceFactory = { subscribedClubsFactory.create() },
+        ).flow.map { pagingData ->
+            pagingData.map { it.toClub() }
+        }
+    }
+
+    companion object {
+        private const val PAGE_SIZE = 20
     }
 }

--- a/data/club/src/main/java/com/ku_stacks/ku_ring/club/ClubRepositoryImpl.kt
+++ b/data/club/src/main/java/com/ku_stacks/ku_ring/club/ClubRepositoryImpl.kt
@@ -5,12 +5,14 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
 import com.ku_stacks.ku_ring.club.mapper.toClub
+import com.ku_stacks.ku_ring.club.mapper.toClubSummary
 import com.ku_stacks.ku_ring.club.pagingsource.ClubListRequest
 import com.ku_stacks.ku_ring.club.pagingsource.ClubsPagingSource
 import com.ku_stacks.ku_ring.club.pagingsource.SubscribedClubPagingSource
 import com.ku_stacks.ku_ring.domain.Club
 import com.ku_stacks.ku_ring.domain.ClubCategory
 import com.ku_stacks.ku_ring.domain.ClubDivision
+import com.ku_stacks.ku_ring.domain.ClubSummary
 import com.ku_stacks.ku_ring.domain.club.ClubRepository
 import com.ku_stacks.ku_ring.remote.club.ClubClient
 import kotlinx.coroutines.flow.Flow
@@ -50,7 +52,7 @@ class ClubRepositoryImpl @Inject constructor(
         category: ClubCategory,
         division: ClubDivision,
         sortBy: String,
-    ): Flow<PagingData<Club>> {
+    ): Flow<PagingData<ClubSummary>> {
         return Pager(
             config = PagingConfig(pageSize = PAGE_SIZE),
             pagingSourceFactory = {
@@ -63,16 +65,16 @@ class ClubRepositoryImpl @Inject constructor(
                 )
             },
         ).flow.map { pagingData ->
-            pagingData.map { it.toClub() }
+            pagingData.map { it.toClubSummary() }
         }
     }
 
-    override fun getSubscribedClubs(): Flow<PagingData<Club>> {
+    override fun getSubscribedClubs(): Flow<PagingData<ClubSummary>> {
         return Pager(
             config = PagingConfig(pageSize = PAGE_SIZE),
             pagingSourceFactory = { subscribedClubsFactory.create() },
         ).flow.map { pagingData ->
-            pagingData.map { it.toClub() }
+            pagingData.map { it.toClubSummary() }
         }
     }
 

--- a/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
+++ b/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
@@ -11,6 +11,7 @@ import com.ku_stacks.ku_ring.domain.RecruitmentStatus
 import com.ku_stacks.ku_ring.remote.club.response.ClubDetailResponse
 import com.ku_stacks.ku_ring.remote.club.response.ClubListItem
 import com.ku_stacks.ku_ring.remote.club.response.ClubRoomLocation
+import com.ku_stacks.ku_ring.util.toLocalDateTimeOrNull
 import kotlinx.datetime.LocalDateTime
 
 fun ClubDetailResponse.toClub(): Club {
@@ -81,13 +82,5 @@ private inline fun <reified T : Enum<T>> String.toEnumOrDefault(default: T): T {
         enumValueOf(this)
     } catch (e: IllegalArgumentException) {
         default
-    }
-}
-
-private fun String.toLocalDateTimeOrNull(): LocalDateTime? {
-    return try {
-        if (this.isEmpty()) null else LocalDateTime.parse(this)
-    } catch (e: Exception) {
-        null
     }
 }

--- a/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
+++ b/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
@@ -79,9 +79,10 @@ fun ClubListItem.toClub(): Club {
 }
 
 fun ClubListItem.parseRecruitment(): ClubRecruitment? {
-    return if (recruitStartAt.isNotEmpty() && recruitEndAt.isNotEmpty()) {
+    return runCatching {
         val start = LocalDateTime.parse(recruitStartAt)
         val end = LocalDateTime.parse(recruitEndAt)
+
         ClubRecruitment(
             start = start,
             end = end,
@@ -89,9 +90,7 @@ fun ClubListItem.parseRecruitment(): ClubRecruitment? {
             recruitmentStatus = RecruitmentStatus.BEFORE,
             applyLink = null,
         )
-    } else {
-        null
-    }
+    }.getOrNull()
 }
 
 private inline fun <reified T : Enum<T>> String.toEnumOrDefault(default: T): T {

--- a/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
+++ b/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
@@ -6,6 +6,7 @@ import com.ku_stacks.ku_ring.domain.ClubCategory
 import com.ku_stacks.ku_ring.domain.ClubDivision
 import com.ku_stacks.ku_ring.domain.ClubLocation
 import com.ku_stacks.ku_ring.domain.ClubRecruitment
+import com.ku_stacks.ku_ring.domain.ClubSummary
 import com.ku_stacks.ku_ring.domain.RecruitmentStatus
 import com.ku_stacks.ku_ring.remote.club.response.ClubDetailResponse
 import com.ku_stacks.ku_ring.remote.club.response.ClubListItem
@@ -57,8 +58,11 @@ fun ClubDetailResponse.parseRecruitment(): ClubRecruitment? {
     }
 }
 
-fun ClubListItem.toClub(): Club {
-    return Club(
+fun ClubListItem.toClubSummary(): ClubSummary {
+    val start = LocalDateTime.parse(recruitStartAt)
+    val end = LocalDateTime.parse(recruitEndAt)
+
+    return ClubSummary(
         id = id,
         name = name,
         summary = shortIntroduction,
@@ -67,30 +71,9 @@ fun ClubListItem.toClub(): Club {
         posterImageUrl = imageUrl,
         isSubscribed = isSubscribed,
         subscribeCount = subscriberCount,
-        recruitment = parseRecruitment(),
-        // 하위 속성들은 사용되지 않음
-        location = null,
-        applyQualification = null,
-        webUrl = null,
-        descriptionImageUrl = null,
-        description = "",
-        affiliation = ClubAffiliation.CENTRAL,
+        recruitmentStart = start,
+        recruitmentEnd = end,
     )
-}
-
-fun ClubListItem.parseRecruitment(): ClubRecruitment? {
-    return runCatching {
-        val start = LocalDateTime.parse(recruitStartAt)
-        val end = LocalDateTime.parse(recruitEndAt)
-
-        ClubRecruitment(
-            start = start,
-            end = end,
-            // 하위 속성들은 사용되지 않음
-            recruitmentStatus = RecruitmentStatus.BEFORE,
-            applyLink = null,
-        )
-    }.getOrNull()
 }
 
 private inline fun <reified T : Enum<T>> String.toEnumOrDefault(default: T): T {

--- a/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
+++ b/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
@@ -8,6 +8,7 @@ import com.ku_stacks.ku_ring.domain.ClubLocation
 import com.ku_stacks.ku_ring.domain.ClubRecruitment
 import com.ku_stacks.ku_ring.domain.RecruitmentStatus
 import com.ku_stacks.ku_ring.remote.club.response.ClubDetailResponse
+import com.ku_stacks.ku_ring.remote.club.response.ClubListItem
 import com.ku_stacks.ku_ring.remote.club.response.ClubRoomLocation
 import kotlinx.datetime.LocalDateTime
 
@@ -50,6 +51,43 @@ fun ClubDetailResponse.parseRecruitment(): ClubRecruitment? {
             recruitmentStatus = recruitmentStatus.uppercase()
                 .toEnumOrDefault<RecruitmentStatus>(RecruitmentStatus.BEFORE),
             applyLink = applyUrl,
+        )
+    } else {
+        null
+    }
+}
+
+fun ClubListItem.toClub(): Club {
+    return Club(
+        id = id,
+        name = name,
+        summary = shortIntroduction,
+        category = category.uppercase().toEnumOrDefault<ClubCategory>(ClubCategory.OTHERS),
+        division = division.uppercase().toEnumOrDefault<ClubDivision>(ClubDivision.ETC),
+        posterImageUrl = imageUrl,
+        isSubscribed = isSubscribed,
+        subscribeCount = subscriberCount,
+        recruitment = parseRecruitment(),
+        // 하위 속성들은 사용되지 않음
+        location = null,
+        applyQualification = null,
+        webUrl = null,
+        descriptionImageUrl = null,
+        description = "",
+        affiliation = ClubAffiliation.CENTRAL,
+    )
+}
+
+fun ClubListItem.parseRecruitment(): ClubRecruitment? {
+    return if (recruitStartAt.isNotEmpty() && recruitEndAt.isNotEmpty()) {
+        val start = LocalDateTime.parse(recruitStartAt)
+        val end = LocalDateTime.parse(recruitEndAt)
+        ClubRecruitment(
+            start = start,
+            end = end,
+            // 하위 속성들은 사용되지 않음
+            recruitmentStatus = RecruitmentStatus.BEFORE,
+            applyLink = null,
         )
     } else {
         null

--- a/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
+++ b/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
@@ -59,8 +59,8 @@ fun ClubDetailResponse.parseRecruitment(): ClubRecruitment? {
 }
 
 fun ClubListItem.toClubSummary(): ClubSummary {
-    val start = LocalDateTime.parse(recruitStartAt)
-    val end = LocalDateTime.parse(recruitEndAt)
+    val start = recruitStartAt.toLocalDateTimeOrNull()
+    val end = recruitEndAt.toLocalDateTimeOrNull()
 
     return ClubSummary(
         id = id,
@@ -81,5 +81,13 @@ private inline fun <reified T : Enum<T>> String.toEnumOrDefault(default: T): T {
         enumValueOf(this)
     } catch (e: IllegalArgumentException) {
         default
+    }
+}
+
+private fun String.toLocalDateTimeOrNull(): LocalDateTime? {
+    return try {
+        if (this.isEmpty()) null else LocalDateTime.parse(this)
+    } catch (e: Exception) {
+        null
     }
 }

--- a/data/club/src/main/java/com/ku_stacks/ku_ring/club/pagingsource/ClubsPagingSource.kt
+++ b/data/club/src/main/java/com/ku_stacks/ku_ring/club/pagingsource/ClubsPagingSource.kt
@@ -1,0 +1,41 @@
+package com.ku_stacks.ku_ring.club.pagingsource
+
+import com.ku_stacks.ku_ring.remote.club.ClubClient
+import com.ku_stacks.ku_ring.remote.club.response.ClubListItem
+import com.ku_stacks.ku_ring.remote.util.BasePagingSource
+import com.ku_stacks.ku_ring.remote.util.PagingRawData
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+
+class ClubsPagingSource @AssistedInject constructor(
+    private val client: ClubClient,
+    @Assisted private val request: ClubListRequest,
+) : BasePagingSource<ClubListItem>() {
+    @AssistedFactory
+    interface Factory {
+        fun create(request: ClubListRequest): ClubsPagingSource
+    }
+
+    override suspend fun provideData(cursor: Int, size: Int): PagingRawData<ClubListItem> {
+        val response = client.getClubs(
+            request.category,
+            request.division,
+            request.sortBy,
+            cursor,
+            size,
+        )
+        if (response.isSuccessAndDataExists) {
+            val data = response.data!!
+            return PagingRawData(
+                items = data.clubs,
+                hasNext = data.hasNext,
+                nextCursor = data.cursor
+            )
+        } else {
+            throw IllegalStateException(response.resultMsg)
+        }
+    }
+}
+
+data class ClubListRequest(val category: String, val division: String, val sortBy: String)

--- a/data/club/src/main/java/com/ku_stacks/ku_ring/club/pagingsource/SubscribedClubPagingSource.kt
+++ b/data/club/src/main/java/com/ku_stacks/ku_ring/club/pagingsource/SubscribedClubPagingSource.kt
@@ -1,0 +1,31 @@
+package com.ku_stacks.ku_ring.club.pagingsource
+
+import com.ku_stacks.ku_ring.remote.club.ClubClient
+import com.ku_stacks.ku_ring.remote.club.response.ClubListItem
+import com.ku_stacks.ku_ring.remote.util.BasePagingSource
+import com.ku_stacks.ku_ring.remote.util.PagingRawData
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+
+class SubscribedClubPagingSource @AssistedInject constructor(
+    private val client: ClubClient,
+) : BasePagingSource<ClubListItem>() {
+    @AssistedFactory
+    interface Factory {
+        fun create(): SubscribedClubPagingSource
+    }
+
+    override suspend fun provideData(cursor: Int, size: Int): PagingRawData<ClubListItem> {
+        val response = client.getSubscribedClubs(cursor, size)
+        if (response.isSuccessAndDataExists) {
+            val data = response.data!!
+            return PagingRawData(
+                items = data.clubs,
+                hasNext = data.hasNext,
+                nextCursor = data.cursor
+            )
+        } else {
+            throw IllegalStateException(response.resultMsg)
+        }
+    }
+}

--- a/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/ClubSummary.kt
+++ b/data/domain/src/main/java/com/ku_stacks/ku_ring/domain/ClubSummary.kt
@@ -1,0 +1,16 @@
+package com.ku_stacks.ku_ring.domain
+
+import kotlinx.datetime.LocalDateTime
+
+data class ClubSummary (
+    val id: Int,
+    val name: String,
+    val summary: String,
+    val category: ClubCategory,
+    val division: ClubDivision,
+    val posterImageUrl: String?,
+    val isSubscribed: Boolean,
+    val subscribeCount: Int,
+    val recruitmentStart: LocalDateTime?,
+    val recruitmentEnd: LocalDateTime?,
+)

--- a/data/remote/build.gradle.kts
+++ b/data/remote/build.gradle.kts
@@ -28,6 +28,7 @@ android {
 dependencies {
     implementation(projects.core.util)
     implementation(projects.core.preferences)
+    implementation(libs.androidx.paging.common.ktx)
 
     testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/club/ClubClient.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/club/ClubClient.kt
@@ -3,6 +3,7 @@ package com.ku_stacks.ku_ring.remote.club
 import com.ku_stacks.ku_ring.remote.club.request.ClubSubscribeRequest
 import com.ku_stacks.ku_ring.remote.club.request.ClubUnsubscribeRequest
 import com.ku_stacks.ku_ring.remote.club.response.ClubDetailResponse
+import com.ku_stacks.ku_ring.remote.club.response.ClubListResponse
 import com.ku_stacks.ku_ring.remote.club.response.ClubSubscribeResponse
 import com.ku_stacks.ku_ring.remote.club.response.ClubUnsubscribeResponse
 import com.ku_stacks.ku_ring.remote.util.DefaultResponse
@@ -24,4 +25,19 @@ class ClubClient @Inject constructor(
     suspend fun getClubDetail(
         clubId: Int
     ): DefaultResponse<ClubDetailResponse> = clubService.getClubDetail(clubId)
+
+    suspend fun getClubs(
+        category: String,
+        division: String,
+        sortBy: String,
+        cursor: Int?,
+        size: Int,
+    ): DefaultResponse<ClubListResponse> =
+        clubService.getClubs(category, division, sortBy, cursor, size)
+
+    suspend fun getSubscribedClubs(
+        cursor: Int?,
+        size: Int,
+    ): DefaultResponse<ClubListResponse> =
+        clubService.getSubscribedClubs(cursor, size)
 }

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/club/ClubService.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/club/ClubService.kt
@@ -3,6 +3,7 @@ package com.ku_stacks.ku_ring.remote.club
 import com.ku_stacks.ku_ring.remote.club.request.ClubSubscribeRequest
 import com.ku_stacks.ku_ring.remote.club.request.ClubUnsubscribeRequest
 import com.ku_stacks.ku_ring.remote.club.response.ClubDetailResponse
+import com.ku_stacks.ku_ring.remote.club.response.ClubListResponse
 import com.ku_stacks.ku_ring.remote.club.response.ClubSubscribeResponse
 import com.ku_stacks.ku_ring.remote.club.response.ClubUnsubscribeResponse
 import com.ku_stacks.ku_ring.remote.util.DefaultResponse
@@ -11,6 +12,7 @@ import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface ClubService {
     @POST("v2/users/bookmarks/clubs")
@@ -27,4 +29,19 @@ interface ClubService {
     suspend fun getClubDetail(
         @Path("id") clubId: Int,
     ): DefaultResponse<ClubDetailResponse>
+
+    @GET("v2/clubs")
+    suspend fun getClubs(
+        @Query("category") category: String,
+        @Query("division") division: String,
+        @Query("sortBy") sortBy: String,
+        @Query("cursor") cursor: Int?,
+        @Query("size") size: Int,
+    ): DefaultResponse<ClubListResponse>
+
+    @GET("v2/users/bookmarks/clubs")
+    suspend fun getSubscribedClubs(
+        @Query("cursor") cursor: Int?,
+        @Query("size") size: Int,
+    ): DefaultResponse<ClubListResponse>
 }

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/club/response/ClubListResponse.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/club/response/ClubListResponse.kt
@@ -1,0 +1,28 @@
+package com.ku_stacks.ku_ring.remote.club.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ClubListResponse(
+    val clubs: List<ClubListItem>,
+    val cursor: Int? = null,
+    val hasNext: Boolean,
+    val totalCount: Int,
+)
+
+@Serializable
+data class ClubListItem(
+    val id: Int,
+    val name: String,
+    @SerialName("summary")
+    val shortIntroduction: String,
+    @SerialName("iconImageUrl")
+    val imageUrl: String,
+    val category: String,
+    val division: String,
+    val isSubscribed: Boolean,
+    val subscriberCount: Int,
+    val recruitStartAt: String,
+    val recruitEndAt: String,
+)

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/BasePagingSource.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/BasePagingSource.kt
@@ -1,0 +1,45 @@
+package com.ku_stacks.ku_ring.remote.util
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+
+abstract class BasePagingSource<Value : Any> : PagingSource<Int, Value>() {
+    /**
+     * API를 조회해 [LoadResult.Page]로 래핑한 결과를 반환합니다.
+     *
+     * @param cursor 조회할 다음 페이지
+     * @param size 조회할 페이지의 크기
+     * @throws IllegalStateException 조회에 실패하면 메시지를 포함한 예외를 던집니다.
+     */
+    abstract suspend fun provideData(cursor: Int, size: Int): PagingRawData<Value>
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Value> {
+        return try {
+            val cursor = params.key ?: 0
+            val size = params.loadSize
+            val (items, hasNext, nextCursor) = provideData(cursor, size)
+
+            LoadResult.Page(
+                data = items,
+                prevKey = null,
+                nextKey = if (hasNext) nextCursor else null
+            )
+
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, Value>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+}
+
+data class PagingRawData<T>(
+    val items: List<T>,
+    val hasNext: Boolean,
+    val nextCursor: Int?,
+)

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/BasePagingSource.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/BasePagingSource.kt
@@ -32,10 +32,7 @@ abstract class BasePagingSource<Value : Any> : PagingSource<Int, Value>() {
     }
 
     override fun getRefreshKey(state: PagingState<Int, Value>): Int? {
-        return state.anchorPosition?.let { anchorPosition ->
-            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
-                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
-        }
+        return null
     }
 }
 

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/BasePagingSource.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/util/BasePagingSource.kt
@@ -9,6 +9,7 @@ abstract class BasePagingSource<Value : Any> : PagingSource<Int, Value>() {
      *
      * @param cursor 조회할 다음 페이지
      * @param size 조회할 페이지의 크기
+     * @return [PagingRawData]로 래핑한 조회 결과
      * @throws IllegalStateException 조회에 실패하면 메시지를 포함한 예외를 던집니다.
      */
     abstract suspend fun provideData(cursor: Int, size: Int): PagingRawData<Value>

--- a/domain/club/build.gradle.kts
+++ b/domain/club/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
 
     implementation(libs.javax.inject)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.androidx.paging.common.ktx)
 }

--- a/domain/club/src/main/java/com/ku_stacks/ku_ring/domain/club/ClubRepository.kt
+++ b/domain/club/src/main/java/com/ku_stacks/ku_ring/domain/club/ClubRepository.kt
@@ -4,6 +4,7 @@ import androidx.paging.PagingData
 import com.ku_stacks.ku_ring.domain.Club
 import com.ku_stacks.ku_ring.domain.ClubCategory
 import com.ku_stacks.ku_ring.domain.ClubDivision
+import com.ku_stacks.ku_ring.domain.ClubSummary
 import kotlinx.coroutines.flow.Flow
 
 interface ClubRepository {
@@ -43,12 +44,12 @@ interface ClubRepository {
         category: ClubCategory,
         division: ClubDivision,
         sortBy: String,
-    ): Flow<PagingData<Club>>
+    ): Flow<PagingData<ClubSummary>>
 
     /**
      * 구독한 동아리 목록을 페이징으로 가져온다.
      *
      * @return 동아리 목록의 [PagingData]를 [Flow]로 반환
      */
-    fun getSubscribedClubs(): Flow<PagingData<Club>>
+    fun getSubscribedClubs(): Flow<PagingData<ClubSummary>>
 }

--- a/domain/club/src/main/java/com/ku_stacks/ku_ring/domain/club/ClubRepository.kt
+++ b/domain/club/src/main/java/com/ku_stacks/ku_ring/domain/club/ClubRepository.kt
@@ -1,6 +1,10 @@
 package com.ku_stacks.ku_ring.domain.club
 
+import androidx.paging.PagingData
 import com.ku_stacks.ku_ring.domain.Club
+import com.ku_stacks.ku_ring.domain.ClubCategory
+import com.ku_stacks.ku_ring.domain.ClubDivision
+import kotlinx.coroutines.flow.Flow
 
 interface ClubRepository {
     /**
@@ -26,4 +30,25 @@ interface ClubRepository {
      * @return 정상 처리 시 동아리의 상세 정보를 [Result]에 담아 반환. 실패 시 [Result.Failure]
      */
     suspend fun getClubDetail(clubId: Int): Result<Club>
+
+    /**
+     * 필터 조건에 맞는 동아리 목록을 페이징으로 가져온다.
+     *
+     * @param category 동아리 카테고리
+     * @param division 동아리 구분
+     * @param sortBy 정렬 기준
+     * @return 동아리 목록의 [PagingData]를 [Flow]로 반환
+     */
+    fun getClubs(
+        category: ClubCategory,
+        division: ClubDivision,
+        sortBy: String,
+    ): Flow<PagingData<Club>>
+
+    /**
+     * 구독한 동아리 목록을 페이징으로 가져온다.
+     *
+     * @return 동아리 목록의 [PagingData]를 [Flow]로 반환
+     */
+    fun getSubscribedClubs(): Flow<PagingData<Club>>
 }


### PR DESCRIPTION
- [동아리 목록 관련 티켓](https://kuring.atlassian.net/browse/KURING-253?atlOrigin=eyJpIjoiNWVmZTdlMjQ2YWQ2NGJkZGE4YzIxMGI3ZjE5NjUzMDUiLCJwIjoiaiJ9)
- [동아리 구독 관련 티켓](https://kuring.atlassian.net/browse/KURING-254?atlOrigin=eyJpIjoiMWE3ZDAzMTIwNWU3NGU5ZTkyMTUwMTAwZjVjODE3YzUiLCJwIjoiaiJ9)

## 요약

- 서버 api 조회 로직을 추가
   - 필터 조건에 맞는 동아리 목록을 커서 페이징으로 조회
   - 사용자가 즐겨찾기한 동아리 목록을 커서 페이징으로 조회
- 각각의 api를 페이징으로 조회하기 위해 PagingSource를 추가
   - 커서를 활용한 페이징 처리 로직을 공통화한 `BasePagingSource`
   - 각 api 별로 `BasePagingSource`를 구현한 PagingSource 클래스를 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 동아리 목록에 페이징 지원 추가(일반 목록·구독 목록) — 카테고리/구분 필터와 정렬 반영
  * 목록에 노출되는 항목 정보 강화(요약 텍스트, 이미지, 구독 상태·수, 모집 시작/종료 시간 포함)

* **테스트/환경**
  * 페이징 관련 라이브러리 및 코루틴 테스트 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->