### PR TITLE
fix: 웹뷰 초기화 실패 시 에러 화면을 보여주도록 수정

### DIFF
--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/KuringWebView.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/KuringWebView.kt
@@ -1,7 +1,6 @@
 package com.ku_stacks.ku_ring.designsystem.components
 
 import android.content.Context
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebChromeClient

--- a/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/KuringWebView.kt
+++ b/core/designsystem/src/main/java/com/ku_stacks/ku_ring/designsystem/components/KuringWebView.kt
@@ -1,6 +1,8 @@
 package com.ku_stacks.ku_ring.designsystem.components
 
 import android.content.Context
+import android.util.Log
+import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
@@ -16,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -32,6 +35,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import com.ku_stacks.ku_ring.designsystem.R
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.KuringTheme
 import com.ku_stacks.ku_ring.designsystem.kuringtheme.values.Pretendard
+import timber.log.Timber
 
 @Composable
 fun KuringWebView(
@@ -39,12 +43,15 @@ fun KuringWebView(
     modifier: Modifier = Modifier,
     customSettings: WebSettings.() -> Unit = {},
 ) {
+    var webViewFailed by remember { mutableStateOf(false) }
+
     // Preview에서 android view를 지원하지 않으므로, 프리뷰가 아닐 때에만 웹뷰를 보여주도록 설정
-    if (url != null && !LocalInspectionMode.current) {
+    if (url != null && !LocalInspectionMode.current && !webViewFailed) {
         KuringWebView(
             url = url,
             customSettings = customSettings,
             modifier = modifier,
+            onWebViewFailed = { webViewFailed = true },
         )
     } else {
         KuringWebViewErrorScreen(modifier = modifier)
@@ -56,6 +63,7 @@ fun KuringWebView(
 private fun KuringWebView(
     url: String,
     customSettings: WebSettings.() -> Unit,
+    onWebViewFailed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var progress by remember { mutableIntStateOf(0) }
@@ -70,14 +78,20 @@ private fun KuringWebView(
         }
         AndroidView(
             factory = { context ->
-                createWebView(
-                    context = context,
-                    onSetProgress = { progress = it },
-                    customSettings = customSettings,
-                )
+                try {
+                    createWebView(
+                        context = context,
+                        onSetProgress = { progress = it },
+                        customSettings = customSettings,
+                    )
+                } catch (e: Exception) {
+                    Timber.e(e)
+                    onWebViewFailed()
+                    View(context)
+                }
             },
             update = {
-                it.loadUrl(url)
+                if (it is WebView) it.loadUrl(url)
             },
         )
     }


### PR DESCRIPTION
### Issue
- Android 16, S25, S24+ 기기에서 웹뷰 로딩 오류 발견.
<img width="757" height="201" alt="image" src="https://github.com/user-attachments/assets/a32d924c-18a6-4dc1-82dc-0e1702fe96db" />

- 구글 이슈트래커에서도 확인했듯이, 삼성 안드로이드 16기기 + `WebView 141.0.7390.122`에서 웹뷰 초기화 시 발생합니다.
- 당장 재현이 불가능하여 우선 `try-catch` 로 처리합니다.

### Reference
- https://issuetracker.google.com/issues/454796299                                                                                                            
- https://issuetracker.google.com/issues/457969917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * WebView 로딩 실패 시 오류 화면을 안정적으로 표시하도록 개선했습니다.
  * 이전 실패 상황 발생 시 WebView 재표시를 방지해 사용자 경험을 향상했습니다.
  * 예외 발생 시 앱 충돌을 방지하고 안전한 대체 뷰로 대체하여 전반적인 안정성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->