### PR TITLE
fix: compose 번들에서 테스트 전용 라이브러리 분리

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -226,10 +226,6 @@ compose = [
     'compose-material-icons-core',
     'compose-material-icons-extended',
     'compose-ui',
-    'compose-ui-test',
-    'compose-ui-test-junit4',
-    'compose-ui-test-manifest',
-    'compose-ui-tooling',
     'compose-ui-tooling-preview',
     'androidx-navigation-compose',
 ]


### PR DESCRIPTION
- compose 번들에 포함된 compose-ui-test, compose-ui-test-junit4, compose-ui-test-manifest, compose-ui-tooling을 제거하여 테스트 라이브러리가 runtime classpath에 유입되는 문제를 해결한다. 
- 이 라이브러리들은 ComposePlugin과 AndroidTestPlugin에서 이미 올바른 configuration(testImpl, androidTestImpl, debugImpl)으로 추가되고 있으므로 번들에서 제거해도 영향이 없다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Compose 라이브러리 의존성 번들에서 테스트 관련 아티팩트가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->