### PR TITLE
Fix/club UI

### DIFF
--- a/core/ui/src/main/java/com/ku_stacks/ku_ring/ui/club/ClubItemCard.kt
+++ b/core/ui/src/main/java/com/ku_stacks/ku_ring/ui/club/ClubItemCard.kt
@@ -114,6 +114,7 @@ fun ClubItemCard(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
+                        modifier = Modifier.weight(1f),
                         text = clubSummary.name,
                         style = KuringTheme.typography.body1.ensureLineHeight(),
                         color = KuringTheme.colors.textTitle,

--- a/feature/club/src/main/java/com/ku_stacks/ku_ring/club/detail/ClubDetailScreen.kt
+++ b/feature/club/src/main/java/com/ku_stacks/ku_ring/club/detail/ClubDetailScreen.kt
@@ -359,6 +359,7 @@ private fun ClubLocationButton(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         Icon(
+            modifier = Modifier.size(24.dp),
             painter = painterResource(id = R.drawable.ic_map_pin_v2),
             contentDescription = null,
             tint = KuringTheme.colors.textBody,


### PR DESCRIPTION
### 수정사항

1. 동아리 상세 페이지 아이콘 사이즈 수정
<img width="304" height="135" alt="image" src="https://github.com/user-attachments/assets/12017050-94c7-439b-9f71-34360a5387ca" />


2. 동아리탭 이름이 긴 동아리의 경우 UI 수정
<img width="347" height="387" alt="image" src="https://github.com/user-attachments/assets/174078ae-eef3-4c19-8849-a3699f4e4f71" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **UI 개선**
  * 클럽 정보 카드의 레이아웃을 개선하여 클럽명이 더 나은 공간 배분을 받도록 조정했습니다.
  * 위치 버튼의 아이콘 크기를 표준화하여 UI 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->