### PR TITLE
Qa/2.5.0 - 동아리 관련

### DIFF
--- a/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
+++ b/data/club/src/main/java/com/ku_stacks/ku_ring/club/mapper/ResponseToDomain.kt
@@ -20,7 +20,7 @@ fun ClubDetailResponse.toClub(): Club {
         category = category.uppercase().toEnumOrDefault<ClubCategory>(ClubCategory.ALL),
         division = division.uppercase().toEnumOrDefault<ClubDivision>(ClubDivision.ETC),
         description = description ?: "",
-        location = location.toLocation(),
+        location = location?.toLocation(),
         applyQualification = qualifications,
         recruitment = parseRecruitment(),
         webUrl = listOfNotNull(instagramUrl, youtubeUrl, etcUrl),

--- a/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/club/response/ClubDetailResponse.kt
+++ b/data/remote/src/main/java/com/ku_stacks/ku_ring/remote/club/response/ClubDetailResponse.kt
@@ -25,7 +25,7 @@ data class ClubDetailResponse(
     val applyUrl: String?,
     @SerialName("posterImageUrl")
     val descriptionImageUrl: String?,
-    val location: ClubRoomLocation,
+    val location: ClubRoomLocation?,
 )
 
 @Serializable

--- a/feature/club/src/main/java/com/ku_stacks/ku_ring/club/subscription/ClubSubscriptionScreen.kt
+++ b/feature/club/src/main/java/com/ku_stacks/ku_ring/club/subscription/ClubSubscriptionScreen.kt
@@ -14,6 +14,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -23,6 +26,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -49,6 +53,18 @@ fun ClubSubscriptionScreen(
 ) {
     val sortOption by viewModel.sortOption.collectAsStateWithLifecycle()
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // 컴포지션 단계에서 refreshClubSubscription으로 인해
+    // 동아리 목록 api가 두 번 이상 호출되는 것을 방지하기 위한 플래그
+    var hasResumedOnce by remember { mutableStateOf(false) }
+
+    LifecycleResumeEffect(Unit) {
+        if (hasResumedOnce) {
+            viewModel.refreshSubscriptions()
+        }
+        hasResumedOnce = true
+        onPauseOrDispose { }
+    }
 
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current

--- a/feature/club/src/main/java/com/ku_stacks/ku_ring/club/subscription/ClubSubscriptionViewModel.kt
+++ b/feature/club/src/main/java/com/ku_stacks/ku_ring/club/subscription/ClubSubscriptionViewModel.kt
@@ -93,6 +93,10 @@ class ClubSubscriptionViewModel @Inject constructor(
                     _subscribedIds.update {
                         result.filter { it.isSubscribed }.map { it.id }.toSet()
                     }
+                    _uiState.update { ClubSubscriptionUiState.Success(result) }
+                }
+                .onFailure { e ->
+                    Timber.e(e)
                 }
         }
     }

--- a/feature/club/src/main/java/com/ku_stacks/ku_ring/club/subscription/ClubSubscriptionViewModel.kt
+++ b/feature/club/src/main/java/com/ku_stacks/ku_ring/club/subscription/ClubSubscriptionViewModel.kt
@@ -85,6 +85,18 @@ class ClubSubscriptionViewModel @Inject constructor(
             }
     }
 
+    fun refreshSubscriptions() {
+        viewModelScope.launch {
+            if (_uiState.value !is ClubSubscriptionUiState.Success) return@launch
+            clubRepository.getSubscribedClubs()
+                .onSuccess { result ->
+                    _subscribedIds.update {
+                        result.filter { it.isSubscribed }.map { it.id }.toSet()
+                    }
+                }
+        }
+    }
+
     fun updateClubSubscription(clubId: Int) {
         val isSubscribed = !_subscribedIds.value.contains(clubId)
         val isSubscribedPrevious =

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/club/compose/ClubListViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/club/compose/ClubListViewModel.kt
@@ -120,7 +120,8 @@ class ClubListViewModel @Inject constructor(
             val filter = _clubListFilter.value ?: return@launch
 
             clubRepository.getClubs(filter.selectedCategory, filter.selectedDivisions)
-                .onSuccess(action = ::updateClubSubscriptionIds)
+                .onSuccess(::updateClubSubscriptionIds)
+                .onFailure(Timber::e)
         }
     }
 

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/club/compose/ClubListViewModel.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/club/compose/ClubListViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ku_stacks.ku_ring.domain.ClubCategory
 import com.ku_stacks.ku_ring.domain.ClubDivision
+import com.ku_stacks.ku_ring.domain.ClubSummary
 import com.ku_stacks.ku_ring.domain.club.ClubRepository
 import com.ku_stacks.ku_ring.domain.club.usecase.ApplyClubSubscriptionUseCase
 import com.ku_stacks.ku_ring.domain.club.usecase.SortClubSummariesUseCase
@@ -67,6 +68,7 @@ class ClubListViewModel @Inject constructor(
 
     init {
         observeInitialCategory()
+        observeFilters()
     }
 
     private fun combineToUiState(
@@ -97,7 +99,7 @@ class ClubListViewModel @Inject constructor(
         }
     }
 
-    fun observeFilters() =
+    private fun observeFilters() {
         viewModelScope.launch {
             _clubListFilter
                 .filterNotNull()
@@ -107,6 +109,20 @@ class ClubListViewModel @Inject constructor(
                     fetchClubSummary(category, divisions)
                 }
         }
+    }
+
+    /**
+     * 로컬과 서버의 동아리 구독 상태를 동기화하기 위한 업데이트 메서드입니다.
+     */
+    fun refreshClubSubscription() {
+        viewModelScope.launch {
+            if (_uiState.value !is ClubListUiState.Success) return@launch
+            val filter = _clubListFilter.value ?: return@launch
+
+            clubRepository.getClubs(filter.selectedCategory, filter.selectedDivisions)
+                .onSuccess(action = ::updateClubSubscriptionIds)
+        }
+    }
 
     fun updateClubSubscription(clubId: Int) {
         val clubSummary = (_uiState.value as? ClubListUiState.Success)?.clubSummaries
@@ -179,12 +195,7 @@ class ClubListViewModel @Inject constructor(
         // API 호출 후 UI 상태 및 구독 상태 업데이트
         clubRepository.getClubs(category, divisions)
             .onSuccess { clubSummaries ->
-                _subscribedIds.update {
-                    clubSummaries.asSequence()
-                        .filter { it.isSubscribed }
-                        .map { it.id }
-                        .toSet()
-                }
+                updateClubSubscriptionIds(clubSummaries)
                 _uiState.update { ClubListUiState.Success(clubSummaries) }
             }
             .onFailure { e ->
@@ -209,5 +220,14 @@ class ClubListViewModel @Inject constructor(
 
     fun updateSortOption(sortOption: ClubSortOption) {
         _clubListFilter.update { it?.copy(sortOption = sortOption) }
+    }
+
+    fun updateClubSubscriptionIds(clubSummaries: List<ClubSummary>) {
+        _subscribedIds.update {
+            clubSummaries.asSequence()
+                .filter { it.isSubscribed }
+                .map { it.id }
+                .toSet()
+        }
     }
 }

--- a/feature/main/src/main/java/com/ku_stacks/ku_ring/main/club/compose/inner_screen/ClubListScreen.kt
+++ b/feature/main/src/main/java/com/ku_stacks/ku_ring/main/club/compose/inner_screen/ClubListScreen.kt
@@ -68,13 +68,17 @@ fun ClubListScreen(
     var isLoginDialogVisible by remember { mutableStateOf(false) }
     var isDivisionBottomSheetVisible by remember { mutableStateOf(false) }
 
+    // 컴포지션 단계에서 refreshClubSubscription으로 인해
+    // 동아리 목록 api가 두 번 이상 호출되는 것을 방지하기 위한 플래그
+    var hasResumedOnce by remember { mutableStateOf(false) }
+
     LifecycleResumeEffect(Unit) {
         isLoginDialogVisible = false
-        val filterJob = viewModel.observeFilters()
-
-        onPauseOrDispose {
-            filterJob.cancel()
+        if (hasResumedOnce) {
+            viewModel.refreshClubSubscription()
         }
+        hasResumedOnce = true
+        onPauseOrDispose { }
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current

--- a/feature/notification/src/main/java/com/ku_stacks/ku_ring/notification/compose/component/SwipeToRevealDeleteBox.kt
+++ b/feature/notification/src/main/java/com/ku_stacks/ku_ring/notification/compose/component/SwipeToRevealDeleteBox.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.IntOffset
@@ -170,6 +171,7 @@ private fun ForegroundContent(
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.weight(1f)
         ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
@@ -192,6 +194,7 @@ private fun ForegroundContent(
                 style = KuringTheme.typography.body1.ensureLineHeight(),
                 color = KuringTheme.colors.textBody,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
 

--- a/feature/notification/src/main/java/com/ku_stacks/ku_ring/notification/compose/preview/NotificationPreviewParameterProvider.kt
+++ b/feature/notification/src/main/java/com/ku_stacks/ku_ring/notification/compose/preview/NotificationPreviewParameterProvider.kt
@@ -10,7 +10,7 @@ class NotificationPreviewParameterProvider : PreviewParameterProvider<Notificati
         id = 1,
         category = NotificationCategory.NOTICE,
         isNew = true,
-        receivedDate = "3일전",
+        receivedDate = "20260330-000000",
         content = NotificationContent.Notice(
             articleId = "1",
             noticeCategory = "공지",


### PR DESCRIPTION
## 요약

- ClubDetailResponse의 location 필드를 `ClubLocation`에서 `ClubLocation?`으로 수정했습니다.
- ClubListScreen이 resume될 때 스크롤 상태가 유지되도록 수정했습니다.
- ClubSubscriptionScreen의 스크롤 유지 및 구독 상태 동기화 로직을 ClubListScreen의 로직처럼 수정했습니다.

## 스샷

|  ClubListScreen 스크롤 유지 | ClubSubsciptionScreen |
|:-------------------------:|:------------------------:|
| <video src="https://github.com/user-attachments/assets/da1dff4f-3a1f-4844-8d8a-e741dd242fd2"></video> | <video src="https://github.com/user-attachments/assets/0dfbe245-2dec-4b23-912b-209dd395b4be"></video> | 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 클럽 상세에서 위치 정보가 없을 때 발생하던 널 예외 방지

* **개선사항**
  * 구독 화면 재방문 시 구독 정보 자동 갱신 동작 추가
  * 클럽 목록에서 재방문 시 구독 상태 동기화 및 수동 갱신 지원 추가

* **UI 개선**
  * 알림 항목 텍스트가 길 때 말줄임 처리로 레이아웃 개선
  * 미리보기 샘플의 수신일 표기값 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->