### PR TITLE
Release CI의 ReleaseUnitTest 오류를 해결

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,4 @@ kotlin.code.style=official
 android.nonTransitiveRClass=false
 android.uniquePackageNames=false
 android.r8.strictFullModeForKeepRules=false
+android.onlyEnableUnitTestForTheTestedBuildType=false


### PR DESCRIPTION
## 요약

**`android.onlyEnableUnitTestForTheTestedBuildType`란?**
AGP 9.x에서 추가된 Gradle 프로퍼티로, testBuildType에 지정된 빌드타입에 대해서만 유닛테스트 태스크를 생성할지 결정합니다.

- **true(기본값)**: testBuildType에 해당하는 빌드타입만 testXxxUnitTest 태스크 생성
- **false**: 모든 빌드타입에 testXxxUnitTest 태스크 생성

## 리뷰
- release CI 실행 중 `testReleaseUnitTest` 단계가 실행되지 않아 문제를 찾던 중 발견한 해결법입니다.
- 정확한 방법인지는 모르겠으나, 실행은 되서 PR 올립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 빌드 구성 설정을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->