### PR TITLE
알림에 BigTextStyle 적용

### DIFF
--- a/core/util/src/main/java/com/ku_stacks/ku_ring/util/KuringNotificationManager.kt
+++ b/core/util/src/main/java/com/ku_stacks/ku_ring/util/KuringNotificationManager.kt
@@ -123,6 +123,7 @@ object KuringNotificationManager {
             .setSmallIcon(smallIconRes)
             .setContentTitle(title)
             .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
             .setSound(defaultSound)
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)

--- a/core/util/src/test/java/com/ku_stacks/ku_ring/util/KuringNotificationManagerTest.kt
+++ b/core/util/src/test/java/com/ku_stacks/ku_ring/util/KuringNotificationManagerTest.kt
@@ -1,0 +1,41 @@
+package com.ku_stacks.ku_ring.util
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class KuringNotificationManagerTest {
+
+    @Test
+    fun `showCustomNotification sets body as big text`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val body = "오늘 19:30 녹색지대 공연 시작\n\nHearts2Hearts\nJANNABI\nZICO"
+
+        KuringNotificationManager.showCustomNotification(
+            context = context,
+            intent = Intent(),
+            title = "녹색지대 DAY1",
+            body = body,
+            largeIconRes = 0,
+            smallIconRes = 0,
+        )
+
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notification = shadowOf(notificationManager).allNotifications.single()
+
+        assertThat(
+            notification.extras.getCharSequence(Notification.EXTRA_BIG_TEXT).toString(),
+            `is`(body),
+        )
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 알림 본문을 BigTextStyle에도 설정해 확장 알림에서 긴 텍스트와 줄바꿈이 표시되도록 했습니다.
- Notification extras의 EXTRA_BIG_TEXT를 확인하는 단위 테스트를 추가했습니다.

## 테스트
- ./gradlew :core:util:testDebugUnitTest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 본문이 큰 텍스트 스타일로 표시됩니다.

* **Tests**
  * 알림 본문 표시 기능에 대한 테스트 케이스 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ku-ring/KU-Ring-Android/pull/730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->